### PR TITLE
reduce navbar height, remove icon, made sticky navbar

### DIFF
--- a/beam/src/components/Navbar.vue
+++ b/beam/src/components/Navbar.vue
@@ -1,8 +1,5 @@
 <template>
 	<nav class="beam__navbar">
-		<slot name="icon">
-			<span class="home-icon">&#11043;</span>
-		</slot>
 		<slot name="title">
 			<h1 class="nav-title">TITLE</h1>
 		</slot>

--- a/beam/themes/beam.css
+++ b/beam/themes/beam.css
@@ -36,15 +36,16 @@ body {
 	padding: 0.625rem;
 	background-color: var(--primary-color);
 	margin-left: 0;
-	min-height: 4em;
-	max-height: 4em;
+	min-height: 2em;
+	max-height: 2em;
 	color: var(--primary-text-color);
 	display: flex;
 	flex-flow: row nowrap;
 	align-content: center;
 	justify-content: flex-start;
 	align-items: center;
-	position: relative;
+	position: sticky;
+	top: 0;
 	border-bottom: 1px solid var(--row-border-color);
 
 	.nav-title {
@@ -188,4 +189,8 @@ body {
 		padding-bottom: 0.625rem;
 		color: var(--primary-text-color);
 	}
+}
+/* workaround for Histoire wrapper breaking sticky functionality with overflow:auto */
+.__histoire-render-story:not(.__histoire-render-custom-controls) {
+	overflow: clip !important;
 }

--- a/common/changes/@stonecrop/beam/beam-navbar-improvements_2024-09-10-15-47.json
+++ b/common/changes/@stonecrop/beam/beam-navbar-improvements_2024-09-10-15-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "updated navbar styling for beam",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/common/changes/@stonecrop/themes/beam-navbar-improvements_2024-09-10-15-47.json
+++ b/common/changes/@stonecrop/themes/beam-navbar-improvements_2024-09-10-15-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/themes",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/themes"
+}

--- a/themes/default/_beam.css
+++ b/themes/default/_beam.css
@@ -1,0 +1,1 @@
+/* TODO: Add Beam styles here to centralize styles */

--- a/themes/default/default-beam.css
+++ b/themes/default/default-beam.css
@@ -1,0 +1,1 @@
+@import url('./_beam.css');


### PR DESCRIPTION
@agritheory I made the updates outlined in #146 . It looks like the navbar is full width to me, but let me know if you are still seeing that issue. 

_I had to add a workaround on one of the Histoire wrapper classes as `overflow:auto` breaks the `position:sticky` functionality of children elements. I put this in the beam.css file and it shouldn't cause any conflicts since the Histoire class name is targets is hyper specific._

![beam-navbar-fix](https://github.com/user-attachments/assets/b5c4f97b-1525-4548-99b8-68966eed2141)
