### PR TITLE
fix: isolate story-specific Beam styles

### DIFF
--- a/beam/themes/beam.css
+++ b/beam/themes/beam.css
@@ -190,7 +190,3 @@ body {
 		color: var(--primary-text-color);
 	}
 }
-/* workaround for Histoire wrapper breaking sticky functionality with overflow:auto */
-.__histoire-render-story:not(.__histoire-render-custom-controls) {
-	overflow: clip !important;
-}

--- a/common/changes/@stonecrop/beam/fix-beam-styles-1_2024-09-16-09-22.json
+++ b/common/changes/@stonecrop/beam/fix-beam-styles-1_2024-09-16-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "isolate story-specific Beam styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/examples/aform/histoire.setup.ts
+++ b/examples/aform/histoire.setup.ts
@@ -1,31 +1,9 @@
 import { defineSetupVue3 } from '@histoire/plugin-vue'
-
-import {
-	ACheckbox,
-	ADate,
-	ADatePicker,
-	ADropdown,
-	AFieldset,
-	AFileAttach,
-	AForm,
-	ANumericInput,
-	ATextInput,
-	Login,
-} from '@stonecrop/aform'
-import { ATable, ATableHeader, ATableModal } from '@stonecrop/atable'
+import { install as AForm, Login } from '@stonecrop/aform'
+import { install as ATable } from '@stonecrop/atable'
 
 export const setupVue3 = defineSetupVue3(({ app }) => {
-	app.component('ACheckbox', ACheckbox)
-	app.component('ADate', ADate)
-	app.component('ADatePicker', ADatePicker)
-	app.component('ADropdown', ADropdown)
-	app.component('AFieldset', AFieldset)
-	app.component('AFileAttach', AFileAttach)
-	app.component('AForm', AForm)
-	app.component('ANumericInput', ANumericInput)
-	app.component('ATable', ATable)
-	app.component('ATableHeader', ATableHeader)
-	app.component('ATableModal', ATableModal)
-	app.component('ATextInput', ATextInput)
+	app.use(AForm)
+	app.use(ATable)
 	app.component('Login', Login)
 })

--- a/examples/atable/histoire.setup.ts
+++ b/examples/atable/histoire.setup.ts
@@ -1,18 +1,8 @@
 import { defineSetupVue3 } from '@histoire/plugin-vue'
-
-import { ADate, AFileAttach, AForm, ANumericInput, ATextInput } from '@stonecrop/aform'
-import { ACell, AExpansionRow, ARow, ATable, ATableHeader, ATableModal } from '@stonecrop/atable'
+import { install as AForm } from '@stonecrop/aform'
+import { install as ATable } from '@stonecrop/atable'
 
 export const setupVue3 = defineSetupVue3(({ app }) => {
-	app.component('ACell', ACell)
-	app.component('ADate', ADate)
-	app.component('AExpansionRow', AExpansionRow)
-	app.component('AForm', AForm)
-	app.component('ANumericInput', ANumericInput)
-	app.component('ARow', ARow)
-	app.component('ATable', ATable)
-	app.component('ATableHeader', ATableHeader)
-	app.component('ATableModal', ATableModal)
-	app.component('ATextInput', ATextInput)
-	app.component('AFileAttach', AFileAttach)
+	app.use(AForm)
+	app.use(ATable)
 })

--- a/examples/beam/histoire.setup.ts
+++ b/examples/beam/histoire.setup.ts
@@ -14,6 +14,8 @@ import {
 } from '@stonecrop/beam'
 import PortalVue from 'portal-vue'
 
+import './overrides.css'
+
 export const setupVue3 = defineSetupVue3(({ app }) => {
 	app.use(PortalVue)
 

--- a/examples/beam/histoire.setup.ts
+++ b/examples/beam/histoire.setup.ts
@@ -1,33 +1,10 @@
 import { defineSetupVue3 } from '@histoire/plugin-vue'
-import {
-	ActionFooter,
-	BeamModal,
-	BeamModalOutlet,
-	Confirm,
-	ItemCheck,
-	ItemCount,
-	ListAnchor,
-	ListItem,
-	ListView,
-	Navbar,
-	ScanInput,
-} from '@stonecrop/beam'
+import { install as Beam } from '@stonecrop/beam'
 import PortalVue from 'portal-vue'
 
 import './overrides.css'
 
 export const setupVue3 = defineSetupVue3(({ app }) => {
 	app.use(PortalVue)
-
-	app.component('ActionFooter', ActionFooter)
-	app.component('BeamModal', BeamModal)
-	app.component('BeamModalOutlet', BeamModalOutlet)
-	app.component('Confirm', Confirm)
-	app.component('ItemCheck', ItemCheck)
-	app.component('ItemCount', ItemCount)
-	app.component('ListAnchor', ListAnchor)
-	app.component('ListItem', ListItem)
-	app.component('ListView', ListView)
-	app.component('Navbar', Navbar)
-	app.component('ScanInput', ScanInput)
+	app.use(Beam)
 })

--- a/examples/beam/overrides.css
+++ b/examples/beam/overrides.css
@@ -1,0 +1,4 @@
+/* workaround for Histoire wrapper breaking sticky functionality with overflow:auto */
+.__histoire-render-story:not(.__histoire-render-custom-controls) {
+	overflow: clip !important;
+}

--- a/examples/code_editor/histoire.setup.ts
+++ b/examples/code_editor/histoire.setup.ts
@@ -1,6 +1,6 @@
 import { defineSetupVue3 } from '@histoire/plugin-vue'
-import { ACodeEditor } from '@stonecrop/code-editor'
+import { install as CodeEditor } from '@stonecrop/code-editor'
 
 export const setupVue3 = defineSetupVue3(({ app }) => {
-	app.component('ACodeEditor', ACodeEditor)
+	app.use(CodeEditor)
 })


### PR DESCRIPTION
Closes #150.

---

So there's a couple things that I think caused the issue in the Beam app:
- The Histoire class overrides added in #147 were being built as part of the main `@stonecrop/beam` package's styles, which was then bundled together with the other dependencies in `agritheory/beam`.
- For some reason (they say it's for security, but there's no documentation around it), Frappe added a [change](https://github.com/frappe/frappe/pull/6351) that blocks Jinja templates/CSS stylesheets from rendering if they have the `.__` string in it, which the class overrides do.

This PR tries to move the class overrides from the main Beam theme to just the histoire instance in `examples/beam`, which prevents them from appearing in downstream installations. I think I was able to retain the sticky functionality, but can you give it another look to confirm @crabinak?

PS: @agritheory I'm also sneaking in a small change (https://github.com/agritheory/stonecrop/commit/5dfe65804483e85a461b8aab48651b7c1b17e1c1) with plugin installation for the Histoire setups. Instead of manually registering the components, I'm moving them to use the install function for each package, which handles the component registration for us. Let me know if they need to move back to granular imports.