### PR TITLE
[beam] fix ItemCount input behaviour

### DIFF
--- a/beam/src/components/ActionFooter.vue
+++ b/beam/src/components/ActionFooter.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(['click'])
+const emit = defineEmits<{ click: [] }>()
 
 const handleFooterAction = () => {
 	emit('click')

--- a/beam/src/components/BeamModal.vue
+++ b/beam/src/components/BeamModal.vue
@@ -8,7 +8,5 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
-	showModal: boolean
-}>()
+defineProps<{ showModal: boolean }>()
 </script>

--- a/beam/src/components/BeamModalOutlet.vue
+++ b/beam/src/components/BeamModalOutlet.vue
@@ -3,7 +3,10 @@
 </template>
 
 <script setup lang="ts">
-// const emit = defineEmits(['confirmmodal', 'closemodal'])
+/* const emit = */ defineEmits<{
+	confirmmodal: []
+	closemodal: []
+}>()
 
 // const confirmModal = () => {
 // 	emit('confirmmodal')

--- a/beam/src/components/ItemCheck.vue
+++ b/beam/src/components/ItemCheck.vue
@@ -1,22 +1,12 @@
 <template>
 	<label class="container">
-		<input type="checkbox" :checked="value" @input="handleInput" tabindex="-1" />
+		<input type="checkbox" v-model="value" tabindex="-1" />
 		<div class="checkmark" tabindex="0"></div>
 	</label>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-
-const emit = defineEmits(['input'])
-// TODO: make this v-model sensitive from parent
-const { value } = defineProps<{ value?: boolean }>()
-
-const checked = ref(value)
-
-const handleInput = () => {
-	emit('input', checked.value)
-}
+const value = defineModel<boolean>({ default: false })
 </script>
 
 <style scoped>

--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -1,10 +1,6 @@
 <template>
 	<div class="beam__itemcount">
-		<span
-			:contenteditable="editable"
-			:class="{ alert: countColor === false }"
-			@input="handleInput"
-			@click="handleInput">
+		<span :contenteditable="editable" :class="{ alert: !isCountComplete }" @input="handleInput" @click="handleInput">
 			{{ count }}
 		</span>
 		<span>/{{ denominator }}</span>
@@ -13,31 +9,25 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 
-const emit = defineEmits(['input'])
+const count = defineModel<number>({ required: true })
 const {
-	value = 0,
 	denominator,
 	uom = '',
 	editable = true,
 } = defineProps<{
-	value?: number
 	denominator: number
 	uom?: string
 	editable?: boolean
 }>()
 
-const count = ref(value)
+const isCountComplete = computed(() => count.value === denominator)
 
 const handleInput = (event: InputEvent | MouseEvent) => {
 	event.preventDefault()
 	event.stopPropagation()
-	count.value = Number((event.target as HTMLElement).innerHTML.replace(/[^0-9]/g, ''))
-	emit('input', count.value)
+	const newValue = Number((event.target as HTMLElement).innerHTML) || 0
+	count.value = Math.min(newValue, denominator)
 }
-
-const countColor = computed(() => {
-	return count.value === denominator
-})
 </script>

--- a/beam/src/components/ListItem.vue
+++ b/beam/src/components/ListItem.vue
@@ -1,17 +1,17 @@
 <template>
 	<li tabindex="0" class="beam__listitem">
 		<div class="beam__listtext">
-			<label>{{ item.label }}</label>
-			<p>{{ item.description }}</p>
+			<label>{{ listItem.label }}</label>
+			<p>{{ listItem.description }}</p>
 		</div>
 
 		<ItemCount
-			v-if="item.count"
+			v-if="listItem.count"
 			v-model="listItem.count.count"
-			:denominator="item.count.of"
-			:uom="item.count.uom"
+			:denominator="listItem.count.of"
+			:uom="listItem.count.uom"
 			:editable="true" />
-		<ItemCheck v-if="item.hasOwnProperty('checked')" v-model="listItem.checked" />
+		<ItemCheck v-if="listItem.hasOwnProperty('checked')" v-model="listItem.checked" />
 	</li>
 </template>
 

--- a/beam/src/components/ListView.vue
+++ b/beam/src/components/ListView.vue
@@ -33,7 +33,7 @@ defineProps<{
 	}[]
 }>()
 
-const emit = defineEmits(['scrollbottom'])
+const emit = defineEmits<{ scrollbottom: [] }>()
 
 onMounted(() => {
 	window.addEventListener('scroll', handleScroll)

--- a/beam/src/components/Navbar.vue
+++ b/beam/src/components/Navbar.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(['click'])
+const emit = defineEmits<{ click: [] }>()
 
 const handlePrimaryAction = () => {
 	emit('click')

--- a/beam/src/components/ScanInput.vue
+++ b/beam/src/components/ScanInput.vue
@@ -9,10 +9,7 @@
 import onScan from 'onscan.js'
 import { onMounted, onUnmounted } from 'vue'
 
-const emit = defineEmits<{
-	scanInstance: [instance: onScan]
-}>()
-
+const emit = defineEmits<{ scanInstance: [instance: onScan] }>()
 const props = defineProps<{
 	scanHandler: (barcode: string, qty: number) => void
 }>()

--- a/common/changes/@stonecrop/beam/fix-item-count_2024-09-24-06-48.json
+++ b/common/changes/@stonecrop/beam/fix-item-count_2024-09-24-06-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "fix ItemCount input behaviour",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/examples/beam/default.story.vue
+++ b/examples/beam/default.story.vue
@@ -111,13 +111,8 @@ const loadMoreItems = () => {
 	}, 300)
 }
 
-const closeModal = () => {
-	showModal.value = false
-}
-
-const confirmModal = () => {
-	showModal.value = false
-}
+const confirmModal = () => (showModal.value = false)
+const closeModal = () => (showModal.value = false)
 </script>
 
 <style>


### PR DESCRIPTION
Closes #155.

---

**Changes:**
- Numeric and non-numeric inputs are better sanitized in ItemCount
- Enable two-way binding in the `ItemCount` and `ItemCheck` components
- Add additional typings for `defineEmits` calls in Beam

---

@agritheory I've also added an implicit check that doesn't allow the count to go beyond the denominator value. Is that a valid check? Or should we allow over-consumption/over-manufacture? Or should we treat this as out of scope and defer?
