### PR TITLE
Feat pinned columns ordering

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -15,7 +15,7 @@
 		@click="handleInput"
 		@mousedown="handleInput"
 		class="atable__cell"
-		:class="hasPinnedColumns ? 'sticky-column' : ''">
+		:class="pinned ? 'sticky-column' : ''">
 		<component
 			v-if="currentColumn.cellComponent"
 			:is="currentColumn.cellComponent"
@@ -45,6 +45,7 @@ const {
 	tableid: string
 	addNavigation?: boolean | KeypressHandlers
 	tabIndex?: number
+	pinned: boolean
 }>()
 
 const tableData = inject<TableDataStore>(tableid)

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
-import { computed, CSSProperties, inject, ref, useTemplateRef } from 'vue'
+import { computed, CSSProperties, inject, ref, useTemplateRef, onMounted } from 'vue'
 
 import TableDataStore from '.'
 import type { CellFormatContext } from '@/types'

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
-import { computed, CSSProperties, inject, ref, useTemplateRef, onMounted } from 'vue'
+import { computed, CSSProperties, inject, ref, useTemplateRef } from 'vue'
 
 import TableDataStore from '.'
 import type { CellFormatContext } from '@/types'
@@ -53,8 +53,6 @@ const cellRef = useTemplateRef<HTMLTableCellElement>('cell')
 const currentColumn = tableData.columns[colIndex]
 const currentData = ref('')
 const cellModified = ref(false)
-
-const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
 
 const displayValue = computed(() => {
 	const data = tableData.cellData<any>(colIndex, rowIndex)

--- a/atable/src/components/ATable.vue
+++ b/atable/src/components/ATable.vue
@@ -135,7 +135,6 @@ const assignStickyCellWidths = () => {
 	}
 	for (let h = 0; h < t.rows[0].cells.length; h++) {
 		const w = t.rows[1].cells[h].innerWidth
-		console.log(w)
 		t.rows[0].cells[h].style.width = w + 'px'
 	}
 }

--- a/atable/src/components/ATable.vue
+++ b/atable/src/components/ATable.vue
@@ -87,6 +87,13 @@ const {
 	tableid?: string
 }>()
 
+const getLeftPosition = (index, colWidth) => {
+	if (index != 0) {
+		return index * colWidth
+	}
+	return 0
+}
+
 const emit = defineEmits(['update:modelValue'])
 
 const rowsValue = modelValue ? modelValue : rows

--- a/atable/src/components/ATable.vue
+++ b/atable/src/components/ATable.vue
@@ -21,6 +21,7 @@
 						:tableid="tableData.id"
 						:col="col"
 						spellcheck="false"
+						:pinned="col.pinned"
 						:rowIndex="rowIndex"
 						:colIndex="colIndex + (tableData.zeroColumn ? 0 : -1)"
 						:component="col.cellComponent"

--- a/atable/src/components/ATable.vue
+++ b/atable/src/components/ATable.vue
@@ -1,5 +1,6 @@
 <template>
 	<table
+		ref="table"
 		class="atable"
 		:style="{ width: tableData.config.fullWidth ? '100%' : 'auto' }"
 		v-on-click-outside="closeModal">
@@ -62,7 +63,7 @@
 
 <script setup lang="ts">
 import { vOnClickOutside } from '@vueuse/components'
-import { nextTick, provide, watch } from 'vue'
+import { nextTick, provide, watch, onMounted, useTemplateRef } from 'vue'
 
 import TableDataStore from '.'
 import ACell from '@/components/ACell.vue'
@@ -108,6 +109,36 @@ watch(
 	{ deep: true }
 )
 
+const table = useTemplateRef('table')
+
+onMounted(() => {
+	assignStickyCellWidths()
+})
+
+const assignStickyCellWidths = () => {
+	const t = table.value
+
+	for (var i = 0, row; (row = t.rows[i]); i++) {
+		let totalWidth = 0
+		let columns = []
+		for (var j = 0, col; (col = row.cells[j]); j++) {
+			if (col.classList.contains('sticky-column') || col.classList.contains('sticky-index')) {
+				col.style.left = totalWidth + 'px'
+				totalWidth += col.offsetWidth
+				columns.push(col)
+			}
+		}
+		if (columns.length > 0) {
+			let lastColumn = columns[columns.length - 1]
+			if (!lastColumn.classList.contains('sticky-column-edge')) lastColumn.classList.add('sticky-column-edge')
+		}
+	}
+	for (let h = 0; h < t.rows[0].cells.length; h++) {
+		const w = t.rows[1].cells[h].innerWidth
+		console.log(w)
+		t.rows[0].cells[h].style.width = w + 'px'
+	}
+}
 // const formatCell = (event?: KeyboardEvent, column?: TableColumn, cellData?: any) => {
 // 	let colIndex: number
 // 	const target = event?.target as HTMLTableCellElement

--- a/atable/src/components/ATableHeader.vue
+++ b/atable/src/components/ATableHeader.vue
@@ -1,8 +1,13 @@
 <template>
 	<thead id="resizable" v-if="columns.length">
 		<tr class="atable-header-row" tabindex="-1">
-			<th v-if="tableData.zeroColumn" id="header-index" />
-			<th v-for="(column, colKey) in columns" :key="column.name" tabindex="-1" :style="getHeaderCellStyle(column)">
+			<th v-if="tableData.zeroColumn" id="header-index" :class="hasPinnedColumns ? 'sticky-index' : ''" />
+			<th
+				v-for="(column, colKey) in columns"
+				:key="column.name"
+				tabindex="-1"
+				:style="getHeaderCellStyle(column)"
+				:class="column.pinned ? 'sticky-column' : ''">
 				<slot>{{ column.label || String.fromCharCode(colKey + 97).toUpperCase() }}</slot>
 			</th>
 		</tr>
@@ -10,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { CSSProperties, inject } from 'vue'
+import { CSSProperties, inject, computed } from 'vue'
 
 import TableDataStore from '.'
 import type { TableColumn } from '@/types'
@@ -24,6 +29,8 @@ const getHeaderCellStyle = (column: TableColumn): CSSProperties => ({
 	textAlign: column.align || 'center',
 	width: tableData.config.fullWidth ? 'auto' : null,
 })
+
+const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
 </script>
 
 <style>

--- a/atable/src/components/ATableHeader.vue
+++ b/atable/src/components/ATableHeader.vue
@@ -24,13 +24,13 @@ const { columns, tableid } = defineProps<{ columns: TableColumn[]; tableid?: str
 
 const tableData = inject<TableDataStore>(tableid)
 
+const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
+
 const getHeaderCellStyle = (column: TableColumn): CSSProperties => ({
 	minWidth: column.width || '40ch',
 	textAlign: column.align || 'center',
 	width: tableData.config.fullWidth ? 'auto' : null,
 })
-
-const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
 </script>
 
 <style>

--- a/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "added pinned columns via sticky positioning",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@stonecrop/atable",
       "comment": "added pinned columns via sticky positioning",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/atable"

--- a/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/themes",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/themes"
+}

--- a/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@stonecrop/themes",
-      "comment": "",
-      "type": "none"
+      "comment": "add styles for pinned columns ordering",
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/themes"

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -104,7 +104,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: false,
 		width: '30ch',
-		pinned: true,
+		pinned: false,
 		format: (value: { title?: string; value?: any }) => `${value.title}`,
 	},
 	{
@@ -114,6 +114,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: true,
 		width: '20ch',
+		pinned: true,
 	},
 	{
 		label: 'Report Date',

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -104,7 +104,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: false,
 		width: '30ch',
-		pinned: false,
+		pinned: true,
 		format: (value: { title?: string; value?: any }) => `${value.title}`,
 	},
 	{
@@ -114,7 +114,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: true,
 		width: '20ch',
-		pinned: true,
+		pinned: false,
 	},
 	{
 		label: 'Report Date',

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -104,7 +104,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: false,
 		width: '30ch',
-		pinned: false,
+		pinned: true,
 		format: (value: { title?: string; value?: any }) => `${value.title}`,
 	},
 	{
@@ -123,6 +123,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'center',
 		edit: true,
 		width: '25ch',
+		pinned: false,
 		modalComponent: 'ADate',
 		format: (value: number) => {
 			return new Date(Number(value)).toLocaleDateString('en-US')

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -104,7 +104,7 @@ const pinned_columns: TableColumn[] = [
 		align: 'left',
 		edit: false,
 		width: '30ch',
-		pinned: true,
+		pinned: false,
 		format: (value: { title?: string; value?: any }) => `${value.title}`,
 	},
 	{

--- a/themes/default/_table.css
+++ b/themes/default/_table.css
@@ -77,6 +77,7 @@ Holds styles for all tables, TH, TR, TD, etc.
 	border-top: 1px solid var(--row-border-color);
 	height: var(--atable-row-height);
 	display: flex;
+	background-color: white;
 }
 
 .list-index {
@@ -93,14 +94,15 @@ Holds styles for all tables, TH, TR, TD, etc.
 
 .sticky-index {
 	position: sticky;
-	left: 0;
+	left: 0px;
 	z-index: 1;
 	order: 0;
+	background-color: white;
 }
 
 .sticky-column {
 	position: sticky;
-	left: 0;
+	left: 40px;
 	z-index: 1;
 	order: 0;
 }

--- a/themes/default/_table.css
+++ b/themes/default/_table.css
@@ -50,6 +50,15 @@ Holds styles for all tables, TH, TR, TD, etc.
 	padding-bottom: var(--atable-row-padding);
 	border-spacing: 0px;
 	border-collapse: collapse;
+	width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	order: 1;
+
+	& span {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 }
 .atable__cell:focus,
 .atable__cell:focus-within {
@@ -67,6 +76,7 @@ Holds styles for all tables, TH, TR, TD, etc.
 .table-row {
 	border-top: 1px solid var(--row-border-color);
 	height: var(--atable-row-height);
+	display: flex;
 }
 
 .list-index {
@@ -76,18 +86,23 @@ Holds styles for all tables, TH, TR, TD, etc.
 	padding-right: 1em;
 	text-align: center;
 	user-select: none;
-	width: v-bind(numberedRowWidth);
-	max-width: v-bind(numberedRowWidth);
+	width: 30px;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .sticky-index {
 	position: sticky;
 	left: 0;
 	z-index: 1;
+	order: 0;
 }
 
 .sticky-column {
-	/* TODO: apply sticky column dynamically */
+	position: sticky;
+	left: 0;
+	z-index: 1;
+	order: 0;
 }
 
 .tree-index {
@@ -102,8 +117,12 @@ Holds styles for all tables, TH, TR, TD, etc.
 }
 
 .atable #header-index {
-	width: v-bind(numberedRowWidth);
-	max-width: v-bind(numberedRowWidth);
+	width: 30px;
+	padding-right: 1em;
+	padding-left: 0;
+}
+.atable-header-row {
+	display: flex;
 }
 
 .atable th {

--- a/themes/default/_table.css
+++ b/themes/default/_table.css
@@ -50,7 +50,7 @@ Holds styles for all tables, TH, TR, TD, etc.
 	padding-bottom: var(--atable-row-padding);
 	border-spacing: 0px;
 	border-collapse: collapse;
-	width: 200px;
+
 	overflow: hidden;
 	text-overflow: ellipsis;
 	order: 1;
@@ -92,21 +92,6 @@ Holds styles for all tables, TH, TR, TD, etc.
 	overflow: hidden;
 }
 
-.sticky-index {
-	position: sticky;
-	left: 0px;
-	z-index: 1;
-	order: 0;
-	background-color: white;
-}
-
-.sticky-column {
-	position: sticky;
-	left: 40px;
-	z-index: 1;
-	order: 0;
-}
-
 .tree-index {
 	color: var(--header-text-color);
 	font-weight: bold;
@@ -139,6 +124,11 @@ Holds styles for all tables, TH, TR, TD, etc.
 	height: var(--atable-row-height);
 	font-weight: 300;
 	letter-spacing: 0.05rem;
+	order: 1;
+	box-sizing: border-box;
+}
+#header-index {
+	box-sizing: content-box;
 }
 
 .atable th:focus {
@@ -148,4 +138,27 @@ Holds styles for all tables, TH, TR, TD, etc.
 	z-index: 100;
 	position: absolute;
 	background-color: var(--row-color-zebra-dark);
+}
+
+.sticky-index {
+	position: sticky;
+	left: 0px;
+	z-index: 1;
+	order: 0;
+}
+
+.sticky-column,
+th.sticky-column,
+td.sticky-column,
+th.sticky-index,
+td.sticky-index {
+	position: sticky;
+	left: 40px;
+	z-index: 1;
+	order: 0;
+	background: white;
+}
+.sticky-column-edge {
+	border-right: 1px solid var(--row-border-color);
+	border-right-width: 1px;
 }

--- a/themes/default/_table.css
+++ b/themes/default/_table.css
@@ -153,7 +153,6 @@ td.sticky-column,
 th.sticky-index,
 td.sticky-index {
 	position: sticky;
-	left: 40px;
 	z-index: 1;
 	order: 0;
 	background: white;

--- a/themes/default/_table.css
+++ b/themes/default/_table.css
@@ -65,12 +65,14 @@ Holds styles for all tables, TH, TR, TD, etc.
 	background-color: var(--focus-cell-background);
 	outline-width: 2px;
 	outline-style: solid;
+	outline-offset: -1px;
 	outline-color: var(--focus-cell-outline);
 	box-shadow: none;
 	overflow: hidden;
 	min-height: 1.15em;
 	max-height: 1.15em;
 	overflow: hidden;
+	box-sizing: border-box;
 }
 
 .table-row {


### PR DESCRIPTION
@agritheory @Alchez Referencing #142 I managed to get this working I think. 

Since the cells needed width data, this could only be gathered after the component mounts, so I added some code in the onMounted hook on the ATable component that gets a ref to the table and traverses through the cells, setting their correct left position if they are pinned. There is also a section that then corrects the heading widths based on their columns widths. You can try pinning various columns. I also added a border to the right edge of the last sticky item in each row to help visualize the break between pinned and non-pinned columns. 

I am not sure if the user will be able to resize columns on the fly, but I put all this into a single function that could be called on a column resize event to adjust all cells to proper values if needed.

There is one small bug that occurs where if the scrolling parent container is smaller than the column width + left position, it will begin to scroll again (this is just how sticky positioning works in relation to parent containers). I'll look into a workaround for this as it might come up if every column happens to be sticky (I do not know if that is a possible situation that may occur). I think there might be an answer somewhere in using absolute positioning over sticky positions, but I'll have to explore that more. 

I'm requesting this merge into the feat-pinned-columns branch since I branched off that. 