### PR TITLE
[atable] fix: array loop structure

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
-import { computed, CSSProperties, inject, ref, useTemplateRef, onMounted } from 'vue'
+import { computed, CSSProperties, inject, ref, useTemplateRef } from 'vue'
 
 import TableDataStore from '.'
 import type { CellFormatContext } from '@/types'
@@ -53,8 +53,6 @@ const cellRef = useTemplateRef<HTMLTableCellElement>('cell')
 const currentColumn = tableData.columns[colIndex]
 const currentData = ref('')
 const cellModified = ref(false)
-
-const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
 
 const displayValue = computed(() => {
 	const data = tableData.cellData<any>(colIndex, rowIndex)

--- a/atable/src/components/ATableHeader.vue
+++ b/atable/src/components/ATableHeader.vue
@@ -24,13 +24,13 @@ const { columns, tableid } = defineProps<{ columns: TableColumn[]; tableid?: str
 
 const tableData = inject<TableDataStore>(tableid)
 
+const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
+
 const getHeaderCellStyle = (column: TableColumn): CSSProperties => ({
 	minWidth: column.width || '40ch',
 	textAlign: column.align || 'center',
 	width: tableData.config.fullWidth ? 'auto' : null,
 })
-
-const hasPinnedColumns = computed(() => tableData.columns.some(col => col.pinned))
 </script>
 
 <style>

--- a/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/atable/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@stonecrop/atable",
       "comment": "added pinned columns via sticky positioning",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/atable"

--- a/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
+++ b/common/changes/@stonecrop/themes/feat-pinned-columns-ordering_2024-09-29-18-41.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@stonecrop/themes",
-      "comment": "",
-      "type": "none"
+      "comment": "add styles for pinned columns ordering",
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/themes"


### PR DESCRIPTION
@crabinak These are minor improvements to the for loops you had previously. They use the ES6 `for...of` syntax that should help with readability. I've also removed some unused imports and functions, but let me know if this looks okay before it goes to your branch.