### PR TITLE
[beam] metadata refactor

### DIFF
--- a/beam/src/components/BeamMetadata.vue
+++ b/beam/src/components/BeamMetadata.vue
@@ -1,55 +1,33 @@
 <template>
 	<div class="beam_metadata">
 		<div class="beam_metadata_content">
-			<div class="beam_metadata_header beam_metadata--two-column">
-				<h1 class="beam_metadata_header-order-num">
-					{{ order.orderNumber }} <span class="beam_metadata--normal">{{ order.product }}</span>
-				</h1>
-				<div :class="{ alert: !order.complete }" class="beam_metadata_count">
-					<p>{{ order.quantity }}/{{ order.total }}</p>
-				</div>
-			</div>
-			<div class="beam_metadata_block">
-				<p class="beam_metadata_heading">
-					Status:
-					<span :class="{ alert: !order.complete }" class="beam_metadata--normal">{{
-						order.complete ? 'Complete' : 'In Progress'
-					}}</span>
-				</p>
-			</div>
-			<div class="beam_metadata_shipping beam_metadata_block">
-				<div class="beam_metadata_source">
-					<p class="beam_metadata_heading">Source</p>
-					<p>
-						Packing Warehouse Inc.<br />
-						1432 W. Parkway Ave.<br />
-						Chicago, IL 60617
+			<slot>
+				<div class="beam_metadata_header beam_metadata--two-column"></div>
+				<div class="beam_metadata_block">
+					<p class="beam_metadata_heading">
+						Status:
+						<span :class="{ alert: !order.complete }" class="beam_metadata--normal">{{
+							order.complete ? 'Complete' : 'In Progress'
+						}}</span>
 					</p>
 				</div>
-				<div class="beam_metadata_arrow">
-					<div class="beam_metadata_arrow-body"></div>
-					<div class="beam_metadata_arrow-head">
-						<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6.74 7.78">
-							<polygon points="6.74 3.89 0 0 0 7.78 6.74 3.89" style="fill: #c4c4c4" />
-						</svg>
+				<div class="beam_metadata_shipping beam_metadata_block">
+					<div class="beam_metadata_source">
+						<p class="beam_metadata_heading">Source</p>
+					</div>
+					<div class="beam_metadata_arrow">
+						<div class="beam_metadata_arrow-body"></div>
+						<div class="beam_metadata_arrow-head">
+							<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6.74 7.78">
+								<polygon points="6.74 3.89 0 0 0 7.78 6.74 3.89" style="fill: #c4c4c4" />
+							</svg>
+						</div>
+					</div>
+					<div class="beam_metadata_source">
+						<p class="beam_metadata_heading">Receiving</p>
 					</div>
 				</div>
-				<div class="beam_metadata_source">
-					<p class="beam_metadata_heading">Receiving</p>
-					<p>
-						Packing Warehouse Inc.<br />
-						1432 W. Parkway Ave.<br />
-						Chicago, IL 60617
-					</p>
-				</div>
-			</div>
-			<div class="beam_metadata_component_header beam_metadata_block">
-				<p class="beam_metadata_heading">Components</p>
-				<p class="beam_metadata_heading">Quantity</p>
-			</div>
-		</div>
-		<div class="beam_metadata_components">
-			<slot name="components"></slot>
+			</slot>
 		</div>
 	</div>
 </template>

--- a/examples/beam/default.story.vue
+++ b/examples/beam/default.story.vue
@@ -28,9 +28,22 @@
 			</template>
 
 			<BeamMetadata :order="workOrder">
-				<template #components>
-					<ListView :items="items" @scrollbottom="loadMoreItems" />
-				</template>
+				<div class="beam_metadata_shipping beam_metadata_block">
+					<div class="beam_metadata_source">
+						<p class="beam_metadata_heading">Source</p>
+					</div>
+					<div class="beam_metadata_arrow">
+						<div class="beam_metadata_arrow-body"></div>
+						<div class="beam_metadata_arrow-head">
+							<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6.74 7.78">
+								<polygon points="6.74 3.89 0 0 0 7.78 6.74 3.89" style="fill: #c4c4c4" />
+							</svg>
+						</div>
+					</div>
+					<div class="beam_metadata_source">
+						<p class="beam_metadata_heading">Receiving</p>
+					</div>
+				</div>
 			</BeamMetadata>
 		</Variant>
 	</Story>


### PR DESCRIPTION
This is a (overly) dramatic refactor of the metadata component to remove the addresses, add a slot and remove the 'items' slot/opinion.  There's a lot of good things about the original implementation that I would like to retain, but I'm not sure about the best way to do that; perhaps they should become independent components which would allow them to be reused outside of the metadata component as well. 