### PR TITLE
[node_editor] fix: add edge create, remove

### DIFF
--- a/common/changes/@stonecrop/node-editor/168_edge_connections_2024-10-22-01-17.json
+++ b/common/changes/@stonecrop/node-editor/168_edge_connections_2024-10-22-01-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/node-editor",
+      "comment": "Add handling for edge creation and removal.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/node-editor"
+}

--- a/common/changes/@stonecrop/node-editor/168_edge_connections_2024-10-22-01-17.json
+++ b/common/changes/@stonecrop/node-editor/168_edge_connections_2024-10-22-01-17.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@stonecrop/node-editor",
       "comment": "Add handling for edge creation and removal.",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/node-editor"

--- a/node_editor/src/components/EditableEdge.vue
+++ b/node_editor/src/components/EditableEdge.vue
@@ -87,5 +87,6 @@ export default {
 
 .label-input {
 	text-align: center;
+	width: 40ch;
 }
 </style>

--- a/node_editor/src/components/NodeEditor.vue
+++ b/node_editor/src/components/NodeEditor.vue
@@ -28,7 +28,6 @@
 			:fit-view-on-init="true"
 			v-model="vueFlowElements"
 			@wheel.prevent="onWheel">
-			@connect="onConnect"
 			<template #node-editable="props">
 				<EditableNode v-bind="props" @change="labelChanged($event, props.id)" />
 			</template>

--- a/node_editor/src/components/StateEditor.vue
+++ b/node_editor/src/components/StateEditor.vue
@@ -45,6 +45,8 @@ const elements = computed<FlowElements>({
 		for (const [key, value] of Object.entries(states.value)) {
 			if (value.on) {
 				for (const [edgeKey, edgeValue] of Object.entries(value.on)) {
+					// If the proxy array 'value.on' has more than one edge, 'edgeValue' will contain a proxy object
+					// where 'target' can be accessed. Otherwise, 'edgeValue' will be available directly.
 					const target = edgeValue.target || edgeValue
 					// TODO: handle typescript errors for both types of states
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access

--- a/node_editor/src/components/StateEditor.vue
+++ b/node_editor/src/components/StateEditor.vue
@@ -40,31 +40,26 @@ const elements = computed<FlowElements>({
 			}
 
 			stateHash[key] = el
+		}
 
+		for (const [key, value] of Object.entries(states.value)) {
 			if (value.on) {
 				for (const [edgeKey, edgeValue] of Object.entries(value.on)) {
-					if (Array.isArray(edgeValue)) {
-						for (const edge of edgeValue) {
-							// TODO: handle typescript errors for both types of states
-							// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-							const edgeJson = edge.toJSON()
-							// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-							const target = edgeJson.target.toString()
-							stateElements.push({
-								id: `${key}-${edgeKey}`,
-								target: target,
-								source: key,
-								label: edgeKey,
-								animated: true,
-							})
+					const target = edgeValue.target || edgeValue
+					// TODO: handle typescript errors for both types of states
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+					stateElements.push({
+						id: `${key}-${target}`,
+						source: key,
+						target: target,
+						label: edgeKey,
+						animated: true,
+					})
 
-							// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-							hasInputs[target] = true
-						}
-					}
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					hasInputs[target] = true
 				}
 			}
-
 			index++
 		}
 
@@ -78,6 +73,7 @@ const elements = computed<FlowElements>({
 
 		return stateElements
 	},
+
 	set: newValue => {
 		// update modelValue when elements change
 		onElementsChange(newValue)
@@ -85,7 +81,6 @@ const elements = computed<FlowElements>({
 		// TODO: emit('update:modelValue', modelValue)
 	},
 })
-
 const onElementsChange = (elements: FlowElements) => {
 	const edges: Record<string, Record<string, any>> = {}
 	const idToLabel: Record<string, string> = {}
@@ -104,19 +99,18 @@ const onElementsChange = (elements: FlowElements) => {
 			states[label] = {
 				type: 'final',
 			}
-		} /* else if (el.source && el.target) {
+		} else if (el.source && el.target) {
 			// it's an edge
 			edges[el.source] = edges[el.source] || {}
 			edges[el.source][label] = {
 				target: el.target,
 			}
-		} */ else {
+		} else {
 			// it's a state
 			states[label] = {
 				on: {},
 			}
 		}
-
 		idToLabel[el.id] = label
 	}
 


### PR DESCRIPTION
### Description
Add edge creation and removal handling to NodeEditor.vue

### Testing
Observe dragging a connection from one node to another creates an edge. 
Observe right-clicking the edge removes it.