### PR TITLE
[atable] allow arbitrary HTML in table cells

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -20,8 +20,8 @@
 			v-if="column.cellComponent"
 			:is="column.cellComponent"
 			:value="displayValue"
-			v-bind="column.cellComponentProps">
-		</component>
+			v-bind="column.cellComponentProps" />
+		<div v-else-if="isHtmlValue" v-html="displayValue" />
 		<span v-else>{{ displayValue }}</span>
 	</td>
 </template>
@@ -33,6 +33,7 @@ import { computed, CSSProperties, inject, ref, useTemplateRef } from 'vue'
 
 import TableDataStore from '.'
 import type { CellContext } from '@/types'
+import { isHtmlString } from '@/utils'
 
 const {
 	colIndex,
@@ -85,6 +86,14 @@ const displayValue = computed(() => {
 	}
 
 	return cellData
+})
+
+const isHtmlValue = computed(() => {
+	if (typeof displayValue.value === 'string') {
+		return isHtmlString(displayValue.value)
+	}
+
+	return false
 })
 
 const handleInput = () => {

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -21,7 +21,7 @@
 			:is="column.cellComponent"
 			:value="displayValue"
 			v-bind="column.cellComponentProps" />
-		<div v-else-if="isHtmlValue" v-html="displayValue" />
+		<span v-else-if="isHtmlValue" v-html="displayValue" />
 		<span v-else>{{ displayValue }}</span>
 	</td>
 </template>
@@ -89,11 +89,8 @@ const displayValue = computed(() => {
 })
 
 const isHtmlValue = computed(() => {
-	if (typeof displayValue.value === 'string') {
-		return isHtmlString(displayValue.value)
-	}
-
-	return false
+	// TODO: check if display value is a native DOM element
+	return typeof displayValue.value === 'string' ? isHtmlString(displayValue.value) : false
 })
 
 const handleInput = () => {

--- a/atable/src/utils.ts
+++ b/atable/src/utils.ts
@@ -1,0 +1,5 @@
+export const isHtmlString = (htmlString: string) => {
+	const $temp = document.createElement('div')
+	$temp.innerHTML = htmlString
+	return $temp.firstChild && $temp.firstChild.nodeType === Node.ELEMENT_NODE
+}

--- a/atable/src/utils.ts
+++ b/atable/src/utils.ts
@@ -1,5 +1,4 @@
 export const isHtmlString = (htmlString: string) => {
-	const $temp = document.createElement('div')
-	$temp.innerHTML = htmlString
-	return $temp.firstChild && $temp.firstChild.nodeType === Node.ELEMENT_NODE
+	const $document = new DOMParser().parseFromString(htmlString, 'text/html')
+	return Array.from($document.body.childNodes).some(node => node.nodeType === 1)
 }

--- a/common/changes/@stonecrop/atable/fix-arbitrary-cell-html_2024-10-29-06-17.json
+++ b/common/changes/@stonecrop/atable/fix-arbitrary-cell-html_2024-10-29-06-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "allow arbitrary HTML in table cells",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -27,7 +27,7 @@ const columns: TableColumn[] = [
 		edit: false,
 		width: '40ch',
 		format: (value: { title?: string; value?: any }, context: CellContext) => {
-			return `${value.title} (IP: ${context.row.ip_address})`
+			return `<a href="${value.title}" target="_blank">${value.title} (IP: ${context.row.ip_address})</a>`
 		},
 	},
 	{


### PR DESCRIPTION
Possible solve for https://github.com/agritheory/autoreader/pull/7.

---

**Concerns:**
- I've used Vue's `v-html` directive to render arbitrary HTML strings, but they mention [possible security concerns](https://vuejs.org/guide/essentials/template-syntax#raw-html) from using it, especially if it can render user-provided input.
- Taking the above point further, I'm not sure about the UX for possibly editing cells that have HTML elements as the cell value.

One possible solution that may solve both the concerns is to automatically disallow editing a cell if it's value is HTML, but that feels too restrictive and may possibly be solved with another modal?

What do you think?