### PR TITLE
[atable] [aform] change cell style on value update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,15 @@ jobs:
   changes:
     name: Check for changes
     runs-on: ubuntu-latest
+
     permissions:
       pull-requests: read
+
     outputs:
-      aform: ${{ steps.filter.outputs.aform }}
-      atable: ${{ steps.filter.outputs.atable }}
-      beam: ${{ steps.filter.outputs.beam }}
+      packages: ${{ steps.filter.outputs.changes }}
+
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -24,128 +25,40 @@ jobs:
           atable: atable/**
           beam: beam/**
 
-  aform:
-    name: AForm
+  test:
+    name: ${{ matrix.package }}
     needs: changes
-    if: ${{ needs.changes.outputs.aform == 'true' }}
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
 
     strategy:
       matrix:
-        node: [20.x]
+        package: ${{ fromJSON(needs.changes.outputs.packages) }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Install Node ${{ matrix.node }}
-      uses: actions/setup-node@v4
-      with:
-        cache-dependency-path: '**/config/rush/pnpm-lock.yaml'
-        registry-url: https://registry.npmjs.org/
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: '**/config/rush/pnpm-lock.yaml'
+          registry-url: https://registry.npmjs.org/
 
-    - name: Rush Install
-      run: node common/scripts/install-run-rush.js install
+      - name: Rush Install
+        run: node common/scripts/install-run-rush.js install
 
-    - name: Rush Build
-      run: node common/scripts/install-run-rush.js rebuild --verbose
+      - name: Rush Build
+        run: node common/scripts/install-run-rush.js rebuild --verbose
 
-    - name: Run Tests
-      working-directory: ./aform
-      run: node ../common/scripts/install-run-rushx.js test:coverage
+      - name: Run Tests
+        working-directory: ./${{ matrix.package }}
+        run: node ../common/scripts/install-run-rushx.js test:coverage
 
-    - name: Coverage Report
-      if: always() # Also generate the report if tests are failing
-      uses: davelosert/vitest-coverage-report-action@v2
-      with:
-        working-directory: ./aform
-        file-coverage-mode: 'all'
-        vite-config-path: './vite.config.ts'
-
-  atable:
-    name: ATable
-    needs: changes
-    if: ${{ needs.changes.outputs.atable == 'true' }}
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    strategy:
-      matrix:
-        node: [20.x]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Install Node ${{ matrix.node }}
-      uses: actions/setup-node@v4
-      with:
-        cache-dependency-path: '**/config/rush/pnpm-lock.yaml'
-        registry-url: https://registry.npmjs.org/
-
-    - name: Rush Install
-      run: node common/scripts/install-run-rush.js install
-
-    - name: Rush Build
-      run: node common/scripts/install-run-rush.js rebuild --verbose
-
-    - name: Run Tests
-      working-directory: ./atable
-      run: node ../common/scripts/install-run-rushx.js test:coverage
-
-    - name: Coverage Report
-      if: always() # Also generate the report if tests are failing
-      uses: davelosert/vitest-coverage-report-action@v2
-      with:
-        working-directory: ./atable
-        file-coverage-mode: 'all'
-        vite-config-path: './vite.config.ts'
-
-  beam:
-    name: Beam
-    needs: changes
-    if: ${{ needs.changes.outputs.beam == 'true' }}
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    strategy:
-      matrix:
-        node: [20.x]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Install Node ${{ matrix.node }}
-      uses: actions/setup-node@v4
-      with:
-        cache-dependency-path: '**/config/rush/pnpm-lock.yaml'
-        registry-url: https://registry.npmjs.org/
-
-    - name: Rush Install
-      run: node common/scripts/install-run-rush.js install
-
-    - name: Rush Build
-      run: node common/scripts/install-run-rush.js rebuild --verbose
-
-    - name: Run Tests
-      working-directory: ./beam
-      run: node ../common/scripts/install-run-rushx.js test:coverage
-
-    - name: Coverage Report
-      if: always() # Also generate the report if tests are failing
-      uses: davelosert/vitest-coverage-report-action@v2
-      with:
-        working-directory: ./beam
-        file-coverage-mode: 'all'
-        vite-config-path: './vite.config.ts'
+      - name: Coverage Report
+        if: always() # generate the coverage report even if tests are failing
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./${{ matrix.package }}
+          file-coverage-mode: 'all'
+          vite-config-path: './vite.config.ts'

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -93,6 +93,16 @@ const isHtmlValue = computed(() => {
 	return typeof displayValue.value === 'string' ? isHtmlString(displayValue.value) : false
 })
 
+const cellStyle = computed((): CSSProperties => {
+	return {
+		textAlign: textAlign.value,
+		width: cellWidth.value,
+		backgroundColor: !cellModified.value ? 'inherit' : 'var(--cell-modified-color)',
+		fontWeight: !cellModified.value ? 'inherit' : 'bold',
+		paddingLeft: getIndent(colIndex, tableData.display[rowIndex]?.indent),
+	}
+})
+
 const handleInput = () => {
 	if (column.mask) {
 		// TODO: add masking to cell values
@@ -175,20 +185,12 @@ const onChange = () => {
 	}
 }
 
-const getIndent = (colKey: number, indent: number) => {
-	if (indent && colKey === 0 && indent > 0) {
-		return `${indent}ch`
+const getIndent = (colIndex: number, indentLevel?: number) => {
+	if (indentLevel && colIndex === 0 && indentLevel > 0) {
+		return `${indentLevel}ch`
 	} else {
 		return 'inherit'
 	}
-}
-
-const cellStyle: CSSProperties = {
-	textAlign: textAlign.value,
-	width: cellWidth.value,
-	backgroundColor: !cellModified.value ? 'inherit' : 'var(--cell-modified-color)',
-	fontWeight: !cellModified.value ? 'inherit' : 'bold',
-	paddingLeft: getIndent(colIndex, tableData.display[rowIndex]?.indent),
 }
 </script>
 

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -9,11 +9,11 @@
 		:spellcheck="false"
 		:style="cellStyle"
 		@focus="onFocus"
-		@paste="onChange"
-		@blur="onChange"
-		@input="onChange"
-		@click="handleInput"
-		@mousedown="handleInput"
+		@paste="updateCellData"
+		@blur="updateCellData"
+		@input="updateCellData"
+		@click="showModal"
+		@mousedown="showModal"
 		class="atable__cell"
 		:class="pinned ? 'sticky-column' : ''">
 		<component
@@ -52,20 +52,33 @@ const {
 
 const tableData = inject<TableDataStore>(tableid)
 const cellRef = useTemplateRef<HTMLTableCellElement>('cell')
+const { bottom, left } = useElementBounding(cellRef)
+
+// keep a shallow copy of the original cell value for comparison
+const originalData = tableData.cellData<any>(colIndex, rowIndex)
 const currentData = ref('')
 const cellModified = ref(false)
-const { bottom, left } = useElementBounding(cellRef)
 
 const table = tableData.table
 const column = tableData.columns[colIndex]
 const row = tableData.rows[rowIndex]
 
-const textAlign = computed(() => {
-	return column.align || 'center'
+const textAlign = column.align || 'center'
+const cellWidth = column.width || '40ch'
+
+const isHtmlValue = computed(() => {
+	// TODO: check if display value is a native DOM element
+	return typeof displayValue.value === 'string' ? isHtmlString(displayValue.value) : false
 })
 
-const cellWidth = computed(() => {
-	return column.width || '40ch'
+const cellStyle = computed((): CSSProperties => {
+	return {
+		textAlign,
+		width: cellWidth,
+		backgroundColor: !cellModified.value ? 'inherit' : 'var(--cell-modified-color)',
+		fontWeight: !cellModified.value ? 'inherit' : 'bold',
+		paddingLeft: getIndent(colIndex, tableData.display[rowIndex]?.indent),
+	}
 })
 
 const displayValue = computed(() => {
@@ -88,22 +101,7 @@ const displayValue = computed(() => {
 	return cellData
 })
 
-const isHtmlValue = computed(() => {
-	// TODO: check if display value is a native DOM element
-	return typeof displayValue.value === 'string' ? isHtmlString(displayValue.value) : false
-})
-
-const cellStyle = computed((): CSSProperties => {
-	return {
-		textAlign: textAlign.value,
-		width: cellWidth.value,
-		backgroundColor: !cellModified.value ? 'inherit' : 'var(--cell-modified-color)',
-		fontWeight: !cellModified.value ? 'inherit' : 'bold',
-		paddingLeft: getIndent(colIndex, tableData.display[rowIndex]?.indent),
-	}
-})
-
-const handleInput = () => {
+const showModal = () => {
 	if (column.mask) {
 		// TODO: add masking to cell values
 		// column.mask(event)
@@ -116,7 +114,7 @@ const handleInput = () => {
 		tableData.modal.parent = cellRef.value
 		tableData.modal.top = bottom.value
 		tableData.modal.left = left.value
-		tableData.modal.width = cellWidth.value
+		tableData.modal.width = cellWidth
 
 		if (typeof column.modalComponent === 'function') {
 			tableData.modal.component = column.modalComponent({ table, row, column })
@@ -132,11 +130,11 @@ if (addNavigation) {
 	let handlers = {
 		...defaultKeypressHandlers,
 		...{
-			'keydown.f2': handleInput,
-			'keydown.alt.up': handleInput,
-			'keydown.alt.down': handleInput,
-			'keydown.alt.left': handleInput,
-			'keydown.alt.right': handleInput,
+			'keydown.f2': showModal,
+			'keydown.alt.up': showModal,
+			'keydown.alt.down': showModal,
+			'keydown.alt.left': showModal,
+			'keydown.alt.right': showModal,
 		},
 	}
 
@@ -171,12 +169,14 @@ const onFocus = () => {
 	}
 }
 
-const onChange = () => {
+const updateCellData = () => {
 	if (cellRef.value) {
+		// only apply changes if the cell value has changed after being mounted
+		cellModified.value = cellRef.value.textContent !== originalData
+
 		if (cellRef.value.textContent !== currentData.value) {
 			currentData.value = cellRef.value.textContent
 			cellRef.value.dispatchEvent(new Event('change'))
-			cellModified.value = true // set display instead
 			if (!column.format) {
 				// TODO: need to setup reverse format function
 				tableData.setCellData(rowIndex, colIndex, currentData.value)

--- a/atable/src/components/index.ts
+++ b/atable/src/components/index.ts
@@ -39,7 +39,7 @@ export default class TableDataStore {
 	}
 
 	createDisplayObject(display?: TableDisplay[]) {
-		const defaultDisplay: TableDisplay[] = [Object.assign({}, { modified: false })]
+		const defaultDisplay: TableDisplay[] = [Object.assign({}, { rowModified: false })]
 
 		// TODO: (typing) what is the type of `display` here?
 		if (display) {
@@ -66,7 +66,7 @@ export default class TableDataStore {
 				indent: row.indent || null,
 				isParent: parents.has(rowIndex),
 				isRoot: row.parent === null || row.parent === undefined,
-				modified: false,
+				rowModified: false,
 				open: row.parent === null || row.parent === undefined,
 				parent: row.parent,
 			}
@@ -90,13 +90,16 @@ export default class TableDataStore {
 	}
 
 	setCellData(rowIndex: number, colIndex: number, value: any) {
-		if (this.table[`${colIndex}:${rowIndex}`] !== value) {
-			this.display[rowIndex].modified = true
-		}
-		this.table[`${colIndex}:${rowIndex}`] = value
+		const index = `${colIndex}:${rowIndex}`
 		const col = this.columns[colIndex]
+
+		if (this.table[index] !== value) {
+			this.display[rowIndex].rowModified = true
+		}
+
+		this.table[index] = value
 		this.rows[rowIndex][col.name] = value
-		return this.table[`${colIndex}:${rowIndex}`]
+		return this.table[index]
 	}
 
 	toggleRowExpand(rowIndex: number) {

--- a/atable/src/types/index.ts
+++ b/atable/src/types/index.ts
@@ -36,9 +36,9 @@ export type TableDisplay = {
 	indent?: number
 	isParent?: boolean
 	isRoot?: boolean
-	modified?: boolean
 	open?: boolean
 	parent?: number
+	rowModified?: boolean
 }
 
 export type TableRow = {

--- a/common/changes/@stonecrop/atable/fix-cell-change-color_2024-11-06-07-46.json
+++ b/common/changes/@stonecrop/atable/fix-cell-change-color_2024-11-06-07-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "change cell style on value update",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -106,5 +106,11 @@ const full_width_table = ref({
 })
 </script>
 
+<style>
+:root {
+	--cell-modified-color: yellow;
+}
+</style>
+
 <!-- enter documentation here -->
 <docs lang="md"></docs>


### PR DESCRIPTION
Closes #186.

---

@agritheory The feature described in the ticket kinda already existed, but it wasn't reactive so a cell change wouldn't actually trigger the styles to change. This PR simply makes the styles reactive now.

I'm not sure about the intended colorization API here though, and I see a couple of options (doesn't have to be either-or):
- Keep the status quo, and have the target application (`fab`, etc.) define the necessary custom CSS property (`--cell-modified-color`) in it's CSS stylesheets (or Vue style blocks, scoped or otherwise) at the `:root` level.
  - It seems like the Riverence app already defines this property in its stylesheet, so maybe this change fixes a regression?
- Add an additional key in the table config to define the cell-modified styles, which would allow individual tables (even if there are multiple in the same Vue file) to define it's own colors.

---

Here's some other things to consider that may or may not be out of scope of this PR:
- Currently, only the cell's background color is reactive. Should we consider other style properties like text color?
- Should the applied styles be global for all cells, or should each column define it's own cell-modified schema? Maybe it accepts a function that decides the styles based on the value?