### PR TITLE
[beam] use individual margin styles for extensibility

### DIFF
--- a/beam/src/components/ListView.vue
+++ b/beam/src/components/ListView.vue
@@ -48,12 +48,12 @@ const handleScroll = () => {
 
 <style scoped>
 .beam_list-view {
-	list-style-type: none;
-	margin: var(--sc-list-margin);
-	padding: 0;
-	/* padding-bottom: 2.5em; */
-	margin-top: 1px;
 	font-family: var(--sc-font-family);
+	list-style-type: none;
+	margin-top: 1px;
+	margin-left: var(--sc-list-margin);
+	margin-right: var(--sc-list-margin);
+	padding: 0;
 }
 
 ul.beam_list-view:last-of-type {

--- a/beam/themes/beam.css
+++ b/beam/themes/beam.css
@@ -19,7 +19,7 @@
 	--sc-btn-border: #ccc;
 	--sc-btn-label-color: black;
 
-	--sc-list-margin: 0rem 0.625rem;
+	--sc-list-margin: 0.625rem;
 
 	--sc-cell-changed-color: #d8edff;
 }

--- a/common/changes/@stonecrop/beam/fix-beam-listview-styles_2024-12-03-06-25.json
+++ b/common/changes/@stonecrop/beam/fix-beam-listview-styles_2024-12-03-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "use individual margin styles for extensibility",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}


### PR DESCRIPTION
@crabinak The goal with this one is to reverse the margin on the day-divider elements in https://github.com/agritheory/beam/pull/238 using `calc()`.

I've tried:
- adding a `margin: revert;` on the day-divider styles, but that doesn't revert the parent list-view styles.
- adding a `position: absolute;` to "break" the elements out of the container, but that feels inelegant and requires re-defining the styles specifically for those elements.