### PR TITLE
replaced metadata component borders with horizontal rule

### DIFF
--- a/beam/src/components/BeamMetadata.vue
+++ b/beam/src/components/BeamMetadata.vue
@@ -22,6 +22,7 @@
 				</div>
 			</slot>
 		</div>
+		<hr />
 	</div>
 </template>
 
@@ -41,7 +42,6 @@ defineProps<{
 .beam_metadata {
 	/* margin:3.125rem; */
 	box-sizing: border-box;
-	border: 1px solid black;
 	display: flex;
 	flex-direction: column;
 	max-height: 100vh;
@@ -98,6 +98,14 @@ defineProps<{
 }
 .beam_metadata_components {
 	overflow: scroll;
+}
+hr {
+	display: block;
+	height: 1px;
+	border: 0;
+	border-top: 1px solid var(--sc-row-border-color);
+	margin: 1em 0;
+	padding: 0;
 }
 </style>
 <style>

--- a/common/changes/@stonecrop/beam/fix-beam-metadata-borders_2024-12-05-16-31.json
+++ b/common/changes/@stonecrop/beam/fix-beam-metadata-borders_2024-12-05-16-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "removed borders from metatdata and replzced with horizontal rule",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}


### PR DESCRIPTION
@agritheory I updated the metadata component to use HR elements instead of borders. I seem to recall there was a layout you were attempting where a header and HR were both inline together. Let me know if that is correct and how it is intended to function (is it the header of the component or footer?) and I can implement that. I could be mistaken remembering that though...