### PR TITLE
[beam] Fix navbar btn style

### DIFF
--- a/beam/src/components/BeamBtn.vue
+++ b/beam/src/components/BeamBtn.vue
@@ -21,3 +21,12 @@
 	}
 }
 </style>
+<style>
+.beam_btn a:link,
+.beam_btn a:visited,
+.beam_btn a:hover,
+.beam_btn a:active {
+	text-decoration: none;
+	color: var(--sc-btn-label-color);
+}
+</style>

--- a/common/changes/@stonecrop/beam/fix-navbar-btn-style_2024-12-11-17-54.json
+++ b/common/changes/@stonecrop/beam/fix-navbar-btn-style_2024-12-11-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "added link styles to BeamBtn",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}


### PR DESCRIPTION
@agritheory This should remove that styling issue on the navbar button. It will catch links within BeamBtn and override their styling. This style couldn't be scoped since the a link comes from outside the component, but should be unique enough since it uses the beam_btn class specifically.