### PR TITLE
[atable] use a single Pinia store to manage table data

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -29,23 +29,26 @@ import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@ston
 import { useElementBounding } from '@vueuse/core'
 import { computed, type CSSProperties, ref, useTemplateRef } from 'vue'
 
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../stores/table'
 import { isHtmlString } from '../utils'
 
 const {
 	colIndex,
 	rowIndex,
-	store,
-	addNavigation = true,
 	tabIndex = 0,
+	pinned,
+	addNavigation = true,
+	tableId,
 } = defineProps<{
 	colIndex: number
 	rowIndex: number
-	store: ReturnType<typeof createTableStore>
-	addNavigation?: boolean | KeypressHandlers
 	tabIndex?: number
 	pinned?: boolean
+	addNavigation?: boolean | KeypressHandlers
+	tableId: string
 }>()
+
+const store = useTableStore()
 
 const emit = defineEmits<{ cellInput: [colIndex: number, rowIndex: number, newValue: string, oldValue: string] }>()
 
@@ -53,17 +56,17 @@ const cellRef = useTemplateRef<HTMLTableCellElement>('cell')
 const { width, height } = useElementBounding(cellRef)
 
 // keep a shallow copy of the original cell value for comparison
-const originalData = store.getCellData(colIndex, rowIndex)
+const originalData = store.getCellData(tableId, colIndex, rowIndex)
 const currentData = ref('')
 const cellModified = ref(false)
 
-const column = store.columns[colIndex]
-const row = store.rows[rowIndex]
+const column = store.columns[tableId][colIndex]
+const row = store.rows[tableId][rowIndex]
 
 const textAlign = column.align || 'center'
 const cellWidth = column.width || '40ch'
 
-const displayValue = computed(() => store.getCellDisplayValue(colIndex, rowIndex))
+const displayValue = computed(() => store.getCellDisplayValue(tableId, colIndex, rowIndex))
 const isHtmlValue = computed(() => {
 	// TODO: check if display value is a native DOM element
 	return typeof displayValue.value === 'string' ? isHtmlString(displayValue.value) : false
@@ -75,7 +78,7 @@ const cellStyle = computed((): CSSProperties => {
 		width: cellWidth,
 		backgroundColor: !cellModified.value ? 'inherit' : 'var(--sc-cell-changed-color)',
 		fontWeight: !cellModified.value ? 'inherit' : 'bold',
-		paddingLeft: store.getIndent(colIndex, store.display[rowIndex]?.indent),
+		paddingLeft: store.getIndent(tableId, colIndex, store.display[tableId][rowIndex]?.indent),
 	}
 })
 
@@ -87,22 +90,22 @@ const showModal = () => {
 
 	if (column.modalComponent) {
 		store.$patch(state => {
-			state.modal.visible = true
-			state.modal.colIndex = colIndex
-			state.modal.rowIndex = rowIndex
-			state.modal.parent = cellRef.value
-			state.modal.top = cellRef.value.offsetTop + cellRef.value.offsetHeight
-			state.modal.left = cellRef.value.offsetLeft
-			state.modal.width = width.value
-			state.modal.height = height.value
+			state.modal[tableId].visible = true
+			state.modal[tableId].colIndex = colIndex
+			state.modal[tableId].rowIndex = rowIndex
+			state.modal[tableId].parent = cellRef.value
+			state.modal[tableId].top = cellRef.value.offsetTop + cellRef.value.offsetHeight
+			state.modal[tableId].left = cellRef.value.offsetLeft
+			state.modal[tableId].width = width.value
+			state.modal[tableId].height = height.value
 
 			if (typeof column.modalComponent === 'function') {
-				state.modal.component = column.modalComponent({ table: state.table, row, column })
+				state.modal[tableId].component = column.modalComponent({ table: state.table[tableId], row, column })
 			} else {
-				state.modal.component = column.modalComponent
+				state.modal[tableId].component = column.modalComponent
 			}
 
-			state.modal.componentProps = column.modalComponentExtraProps
+			state.modal[tableId].componentProps = column.modalComponentExtraProps
 		})
 	}
 }
@@ -161,12 +164,12 @@ const updateCellData = (payload: Event) => {
 
 	// only apply changes if the cell value has changed after being mounted
 	if (column.format) {
-		cellModified.value = target.textContent !== store.getFormattedValue(colIndex, rowIndex, originalData)
+		cellModified.value = target.textContent !== store.getFormattedValue(tableId, colIndex, rowIndex, originalData)
 		// TODO: need to setup reverse format function?
-		store.setCellText(colIndex, rowIndex, target.textContent)
+		store.setCellText(tableId, colIndex, rowIndex, target.textContent)
 	} else {
 		cellModified.value = target.textContent !== originalData
-		store.setCellData(colIndex, rowIndex, target.textContent)
+		store.setCellData(tableId, colIndex, rowIndex, target.textContent)
 	}
 }
 </script>

--- a/atable/src/components/AExpansionRow.vue
+++ b/atable/src/components/AExpansionRow.vue
@@ -1,12 +1,12 @@
 <template>
 	<tr v-bind="$attrs" ref="rowEl" :tabindex="tabIndex" class="expandable-row">
-		<td :tabIndex="-1" @click="store.toggleRowExpand(rowIndex)" class="row-index">
+		<td :tabIndex="-1" @click="store.toggleRowExpand(rowIndex, tableId)" class="row-index">
 			{{ rowExpandSymbol }}
 		</td>
 		<slot name="row" />
 	</tr>
-	<tr v-if="store.display[rowIndex].expanded" ref="rowExpanded" :tabindex="tabIndex" class="expanded-row">
-		<td :tabIndex="-1" :colspan="store.columns.length + 1" class="expanded-row-content">
+	<tr v-if="store.display[tableId][rowIndex].expanded" ref="rowExpanded" :tabindex="tabIndex" class="expanded-row">
+		<td :tabIndex="-1" :colspan="store.columns[tableId].length + 1" class="expanded-row-content">
 			<slot name="content" />
 		</td>
 	</tr>
@@ -16,25 +16,27 @@
 import { type KeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
 import { computed, useTemplateRef } from 'vue'
 
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../stores/table'
 
 const {
 	rowIndex,
-	store,
 	tabIndex = -1,
 	addNavigation,
+	tableId,
 } = defineProps<{
 	rowIndex: number
-	store: ReturnType<typeof createTableStore>
 	tabIndex?: number
 	addNavigation?: boolean | KeypressHandlers
+	tableId: string
 }>()
+
+const store = useTableStore()
 
 const rowRef = useTemplateRef<HTMLTableRowElement>('rowEl')
 // const expandedRowRef = useTemplateRef<HTMLDivElement>('rowExpanded')
 
 const rowExpandSymbol = computed(() => {
-	return store.display[rowIndex].expanded ? '▼' : '►'
+	return store.display[tableId][rowIndex].expanded ? '▼' : '►'
 })
 
 if (addNavigation) {
@@ -42,7 +44,7 @@ if (addNavigation) {
 		'keydown.control.g': (event: KeyboardEvent) => {
 			event.stopPropagation()
 			event.preventDefault()
-			store.toggleRowExpand(rowIndex)
+			store.toggleRowExpand(rowIndex, tableId)
 		},
 	}
 

--- a/atable/src/components/ARow.vue
+++ b/atable/src/components/ARow.vue
@@ -14,7 +14,7 @@
 				:tabIndex="-1"
 				class="tree-index"
 				:class="store.hasPinnedColumns ? 'sticky-index' : ''"
-				@click="store.toggleRowExpand(rowIndex)">
+				@click="store.toggleRowExpand(rowIndex, tableId)">
 				{{ rowExpandSymbol }}
 			</td>
 		</slot>
@@ -28,23 +28,25 @@
 import { type KeypressHandlers, useKeyboardNav, defaultKeypressHandlers } from '@stonecrop/utilities'
 import { useTemplateRef } from 'vue'
 
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../stores/table'
 
 const {
 	rowIndex,
-	store,
 	tabIndex = -1,
 	addNavigation = false, // default to allowing cell navigation
+	tableId,
 } = defineProps<{
 	rowIndex: number
-	store: ReturnType<typeof createTableStore>
 	tabIndex?: number
 	addNavigation?: boolean | KeypressHandlers
+	tableId: string
 }>()
 
+const store = useTableStore()
+
 const rowRef = useTemplateRef<HTMLTableRowElement>('rowEl')
-const isRowVisible = store.isRowVisible(rowIndex)
-const rowExpandSymbol = store.getRowExpandSymbol(rowIndex)
+const isRowVisible = store.isRowVisible(rowIndex, tableId)
+const rowExpandSymbol = store.getRowExpandSymbol(rowIndex, tableId)
 
 if (addNavigation) {
 	let handlers = defaultKeypressHandlers

--- a/atable/src/components/ATable.vue
+++ b/atable/src/components/ATable.vue
@@ -5,22 +5,19 @@
 		:style="{ width: store.config.fullWidth ? '100%' : 'auto' }"
 		v-on-click-outside="store.closeModal">
 		<slot name="header" :data="store">
-			<ATableHeader :columns="store.columns" :store="store" />
+			<ATableHeader :columns="store.columns" :tableId="tableId" />
 		</slot>
 
 		<tbody>
 			<slot name="body" :data="store">
-				<ARow v-for="(row, rowIndex) in store.rows" :key="row.id" :row="row" :rowIndex="rowIndex" :store="store">
+				<ARow v-for="(row, rowIndex) in store.rows[tableId]" :key="row.id" :rowIndex="rowIndex" :tableId="tableId">
 					<ACell
-						v-for="(col, colIndex) in store.columns"
+						v-for="(col, colIndex) in store.columns[tableId]"
 						:key="col.name"
-						:store="store"
-						:col="col"
-						spellcheck="false"
-						:pinned="col.pinned"
-						:rowIndex="rowIndex"
 						:colIndex="colIndex"
-						:component="col.cellComponent"
+						:rowIndex="rowIndex"
+						:pinned="col.pinned"
+						:tableId="tableId"
 						:style="{
 							textAlign: col?.align || 'center',
 							minWidth: col?.width || '40ch',
@@ -34,19 +31,19 @@
 		<slot name="footer" :data="store" />
 		<slot name="modal" :data="store">
 			<ATableModal
-				v-show="store.modal.visible"
-				:colIndex="store.modal.colIndex"
-				:rowIndex="store.modal.rowIndex"
-				:store="store"
+				v-show="store.modal[tableId].visible"
+				:colIndex="store.modal[tableId].colIndex"
+				:rowIndex="store.modal[tableId].rowIndex"
+				:tableId="tableId"
 				:container="tableRef">
 				<template #default>
 					<component
-						:key="`${store.modal.rowIndex}:${store.modal.colIndex}`"
-						:is="store.modal.component"
-						:colIndex="store.modal.colIndex"
-						:rowIndex="store.modal.rowIndex"
-						:store="store"
-						v-bind="store.modal.componentProps" />
+						:key="`${store.modal[tableId].rowIndex}:${store.modal[tableId].colIndex}`"
+						:is="store.modal[tableId].component"
+						:colIndex="store.modal[tableId].colIndex"
+						:rowIndex="store.modal[tableId].rowIndex"
+						:tableId="tableId"
+						v-bind="store.modal[tableId].componentProps" />
 				</template>
 			</ATableModal>
 		</slot>
@@ -62,7 +59,7 @@ import ACell from './ACell.vue'
 import ARow from './ARow.vue'
 import ATableHeader from './ATableHeader.vue'
 import ATableModal from './ATableModal.vue'
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../../../stonecrop/src/stores/table'
 import type { TableColumn, TableConfig, TableRow } from '../types'
 
 const {
@@ -86,12 +83,22 @@ const emit = defineEmits<{
 
 const tableRef = useTemplateRef<HTMLTableElement>('table')
 const rowsValue = modelValue ? modelValue : rows
-const store = createTableStore({ columns, rows: rowsValue, id, config })
+const store = useTableStore()
+const tableId = id || crypto.randomUUID()
+
+store.$patch(state => {
+	state.columns[tableId] = columns
+	state.rows[tableId] = rowsValue
+	state.config = config
+	state.table[tableId] = store.createTableObject(columns, rowsValue)
+	state.display[tableId] = store.createDisplayObject(rowsValue)
+	state.modal[tableId] = { visible: false }
+})
 
 store.$onAction(({ name, store, args, after }) => {
 	if (name === 'setCellData') {
 		const [colIndex, rowIndex, newCellValue] = args
-		const prevCellValue = store.getCellData(colIndex, rowIndex)
+		const prevCellValue = store.getCellData(tableId, colIndex, rowIndex)
 
 		after(() => {
 			emit('cellUpdate', colIndex, rowIndex, newCellValue, prevCellValue)
@@ -100,7 +107,7 @@ store.$onAction(({ name, store, args, after }) => {
 })
 
 watch(
-	() => store.rows,
+	() => store.rows[tableId],
 	newValue => {
 		emit('update:modelValue', newValue)
 	},
@@ -158,11 +165,11 @@ const assignStickyCellWidths = () => {
 
 window.addEventListener('keydown', (event: KeyboardEvent) => {
 	if (event.key === 'Escape') {
-		if (store.modal.visible) {
-			store.modal.visible = false
+		if (store.modal[tableId].visible) {
+			store.modal[tableId].visible = false
 
 			// focus on the parent cell again
-			const $parent = store.modal.parent
+			const $parent = store.modal[tableId].parent
 			if ($parent) {
 				// wait for the modal to close before focusing
 				void nextTick().then(() => {

--- a/atable/src/components/ATableHeader.vue
+++ b/atable/src/components/ATableHeader.vue
@@ -23,13 +23,15 @@
 </template>
 
 <script setup lang="ts">
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../stores/table'
 import type { TableColumn } from '../types'
 
-const { columns, store } = defineProps<{
+const { columns, tableId } = defineProps<{
 	columns: TableColumn[]
-	store: ReturnType<typeof createTableStore>
+	tableId: string
 }>()
+
+const store = useTableStore()
 </script>
 
 <style>

--- a/atable/src/components/ATableModal.vue
+++ b/atable/src/components/ATableModal.vue
@@ -8,14 +8,16 @@
 import { useElementBounding } from '@vueuse/core'
 import { useTemplateRef, computed } from 'vue'
 
-import { createTableStore } from '../stores/table'
+import { useTableStore } from '../stores/table'
 
-const { store, container } = defineProps<{
+const { colIndex, rowIndex, tableId, container } = defineProps<{
 	colIndex?: number
 	rowIndex?: number
-	store?: ReturnType<typeof createTableStore>
+	tableId: string
 	container?: HTMLElement
 }>()
+
+const store = useTableStore()
 
 const amodalRef = useTemplateRef('amodal')
 const { width, height } = useElementBounding(amodalRef)
@@ -30,14 +32,14 @@ const amodalStyles = computed(() => {
 
 	// if this modal would go outside the edge of its container, instead place it above the element (Y) or along the right side (X)
 	const modalLeft =
-		store.modal.left + width.value > containerWidth
-			? store.modal.left - (width.value - store.modal.width)
-			: store.modal.left
+		store.modal[tableId].left + width.value > containerWidth
+			? store.modal[tableId].left - (width.value - store.modal[tableId].width)
+			: store.modal[tableId].left
 
 	const modalTop =
-		store.modal.top + height.value > containerHeight
-			? store.modal.top - height.value - store.modal.height
-			: store.modal.top
+		store.modal[tableId].top + height.value > containerHeight
+			? store.modal[tableId].top - height.value - store.modal[tableId].height
+			: store.modal[tableId].top
 
 	return {
 		left: `${modalLeft}px`,

--- a/atable/src/stores/table.ts
+++ b/atable/src/stores/table.ts
@@ -1,226 +1,90 @@
 import { defineStore } from 'pinia'
-import { type CSSProperties, computed, ref } from 'vue'
+import { ref, computed } from 'vue'
 
-import type { CellContext, TableColumn, TableConfig, TableDisplay, TableModal, TableRow } from '../types'
+export const useTableStore = defineStore('table', () => {
+  const tables = ref<Record<string, any>>({})
 
-/**
- * Create a table store
- * @param initData - Initial data for the table store
- * @returns table store instance
- * @public
- */
-export const createTableStore = (initData: {
-	columns: TableColumn[]
-	rows: TableRow[]
-	id?: string
-	config?: TableConfig
-	table?: { [key: string]: any }
-	display?: TableDisplay[]
-	modal?: TableModal
-}) => {
-	const id = initData.id || crypto.randomUUID()
-	const createStore = defineStore(`table-${id}`, () => {
-		// util functions
-		const createTableObject = () => {
-			const table = {}
-			for (const [colIndex, column] of columns.value.entries()) {
-				for (const [rowIndex, row] of rows.value.entries()) {
-					table[`${colIndex}:${rowIndex}`] = row[column.name]
-				}
-			}
-			return table
-		}
+  const getTable = (tableId: string) => {
+    if (!tables.value[tableId]) {
+      tables.value[tableId] = {
+        columns: [],
+        rows: [],
+        config: {},
+        display: [],
+        modal: { visible: false },
+      }
+    }
+    return tables.value[tableId]
+  }
 
-		const createDisplayObject = (display?: TableDisplay[]) => {
-			const defaultDisplay: TableDisplay[] = [Object.assign({}, { rowModified: false })]
+  const setTableData = (tableId: string, columns: any[], rows: any[], config: any) => {
+    const table = getTable(tableId)
+    table.columns = columns
+    table.rows = rows
+    table.config = config
+    table.display = rows.map(() => ({ expanded: false, indent: 0 }))
+  }
 
-			// TODO: (typing) what is the type of `display` here?
-			if (display) {
-				if ('0:0' in display) {
-					return display
-				}
-				// else if ('default' in display) {
-				// 	// TODO: (typing) what is the possible input here for 'default'?
-				// 	defaultDisplay = display.default
-				// }
-			}
+  const getCellData = (tableId: string, colIndex: number, rowIndex: number) => {
+    const table = getTable(tableId)
+    return table.rows[rowIndex][table.columns[colIndex].name]
+  }
 
-			// TODO: (typing) is this type correct for the parent set?
-			const parents = new Set<string | number>()
-			for (let rowIndex = rows.value.length - 1; rowIndex >= 0; rowIndex--) {
-				const row = rows.value[rowIndex]
-				if (row.parent) {
-					parents.add(row.parent)
-				}
+  const setCellData = (tableId: string, colIndex: number, rowIndex: number, value: any) => {
+    const table = getTable(tableId)
+    table.rows[rowIndex][table.columns[colIndex].name] = value
+  }
 
-				defaultDisplay[rowIndex] = {
-					childrenOpen: false,
-					expanded: false,
-					indent: row.indent || null,
-					isParent: parents.has(rowIndex),
-					isRoot: row.parent === null || row.parent === undefined,
-					rowModified: false,
-					open: row.parent === null || row.parent === undefined,
-					parent: row.parent,
-				}
-			}
+  const getCellDisplayValue = (tableId: string, colIndex: number, rowIndex: number) => {
+    const table = getTable(tableId)
+    const column = table.columns[colIndex]
+    const value = getCellData(tableId, colIndex, rowIndex)
+    return column.format ? column.format(value) : value
+  }
 
-			return defaultDisplay
-		}
+  const getFormattedValue = (tableId: string, colIndex: number, rowIndex: number, value: any) => {
+    const table = getTable(tableId)
+    const column = table.columns[colIndex]
+    return column.format ? column.format(value) : value
+  }
 
-		// state
-		const columns = ref(initData.columns)
-		const rows = ref(initData.rows)
-		const config = ref(initData.config || {})
-		const table = ref(initData.table || createTableObject())
-		const display = ref(createDisplayObject(initData.display))
-		const modal = ref(initData.modal || { visible: false })
-		const updates = ref<Record<string, string>>({})
+  const getIndent = (tableId: string, colIndex: number, indent: number) => {
+    const table = getTable(tableId)
+    return `${indent * 2}ch`
+  }
 
-		// getters
-		const hasPinnedColumns = computed(() => columns.value.some(col => col.pinned))
+  const toggleRowExpand = (tableId: string, rowIndex: number) => {
+    const table = getTable(tableId)
+    table.display[rowIndex].expanded = !table.display[rowIndex].expanded
+  }
 
-		const numberedRowWidth = computed(() => {
-			const indent = Math.ceil(rows.value.length / 100 + 1)
-			return `${indent}ch`
-		})
+  const isRowVisible = (tableId: string, rowIndex: number) => {
+    const table = getTable(tableId)
+    return table.display[rowIndex].expanded
+  }
 
-		const zeroColumn = computed(() => ['list', 'tree', 'list-expansion'].includes(config.value.view))
+  const getRowExpandSymbol = (tableId: string, rowIndex: number) => {
+    const table = getTable(tableId)
+    return table.display[rowIndex].expanded ? '▼' : '►'
+  }
 
-		// actions
-		const getCellData = <T = any>(colIndex: number, rowIndex: number): T => table.value[`${colIndex}:${rowIndex}`]
-		const setCellData = (colIndex: number, rowIndex: number, value: any) => {
-			const index = `${colIndex}:${rowIndex}`
-			const col = columns.value[colIndex]
+  const closeModal = (tableId: string) => {
+    const table = getTable(tableId)
+    table.modal.visible = false
+  }
 
-			if (table.value[index] !== value) {
-				display.value[rowIndex].rowModified = true
-			}
-
-			table.value[index] = value
-			rows.value[rowIndex][col.name] = value
-		}
-
-		const setCellText = (colIndex: number, rowIndex: number, value: string) => {
-			const index = `${colIndex}:${rowIndex}`
-
-			if (table.value[index] !== value) {
-				display.value[rowIndex].rowModified = true
-				updates.value[index] = value
-			}
-		}
-
-		const getHeaderCellStyle = (column: TableColumn): CSSProperties => ({
-			minWidth: column.width || '40ch',
-			textAlign: column.align || 'center',
-			width: config.value.fullWidth ? 'auto' : null,
-		})
-
-		const isRowVisible = (rowIndex: number) => {
-			return config.value.view !== 'tree' || display.value[rowIndex].isRoot || display.value[rowIndex].open
-		}
-
-		const getRowExpandSymbol = (rowIndex: number) => {
-			if (config.value.view !== 'tree') {
-				return ''
-			}
-
-			if (display.value[rowIndex].isRoot || display.value[rowIndex].isParent) {
-				return display.value[rowIndex].childrenOpen ? '-' : '+'
-			}
-
-			return ''
-		}
-
-		const toggleRowExpand = (rowIndex: number) => {
-			if (config.value.view === 'tree') {
-				display.value[rowIndex].childrenOpen = !display.value[rowIndex].childrenOpen
-				for (let index = rows.value.length - 1; index >= 0; index--) {
-					if (display.value[index].parent === rowIndex) {
-						display.value[index].open = !display.value[index].open
-						if (display.value[index].childrenOpen) {
-							toggleRowExpand(index)
-						}
-					}
-				}
-			} else if (config.value.view === 'list-expansion') {
-				display.value[rowIndex].expanded = !display.value[rowIndex].expanded
-			}
-		}
-
-		const getCellDisplayValue = (colIndex: number, rowIndex: number) => {
-			const cellData = getCellData(colIndex, rowIndex)
-			return getFormattedValue(colIndex, rowIndex, cellData)
-		}
-
-		const getFormattedValue = (colIndex: number, rowIndex: number, value: any) => {
-			const column = columns.value[colIndex]
-			const row = rows.value[rowIndex]
-			const format = column.format
-
-			if (!format) {
-				return value
-			}
-
-			if (typeof format === 'function') {
-				return format(value, { table: table.value, row, column })
-			} else if (typeof format === 'string') {
-				// parse format function from string
-				// eslint-disable-next-line @typescript-eslint/no-implied-eval
-				const formatFn: (value: any, context?: CellContext) => string = Function(`"use strict";return (${format})`)()
-				return formatFn(value, { table: table.value, row, column })
-			}
-
-			return value
-		}
-
-		const closeModal = (event: MouseEvent) => {
-			if (!(event.target instanceof Node)) {
-				// if the target is not a node, it's probably a custom click event to Document or Window
-				// err on the side of closing the modal in that case
-				if (modal.value.visible) modal.value.visible = false
-			} else if (!modal.value.parent?.contains(event.target)) {
-				if (modal.value.visible) modal.value.visible = false
-			}
-		}
-
-		const getIndent = (colIndex: number, indentLevel?: number) => {
-			if (indentLevel && colIndex === 0 && indentLevel > 0) {
-				return `${indentLevel}ch`
-			} else {
-				return 'inherit'
-			}
-		}
-
-		return {
-			// state
-			columns,
-			config,
-			display,
-			modal,
-			rows,
-			table,
-			updates,
-
-			// getters
-			hasPinnedColumns,
-			numberedRowWidth,
-			zeroColumn,
-
-			// actions
-			closeModal,
-			getCellData,
-			getCellDisplayValue,
-			getFormattedValue,
-			getHeaderCellStyle,
-			getIndent,
-			getRowExpandSymbol,
-			isRowVisible,
-			setCellData,
-			setCellText,
-			toggleRowExpand,
-		}
-	})
-
-	return createStore()
-}
+  return {
+    tables,
+    getTable,
+    setTableData,
+    getCellData,
+    setCellData,
+    getCellDisplayValue,
+    getFormattedValue,
+    getIndent,
+    toggleRowExpand,
+    isRowVisible,
+    getRowExpandSymbol,
+    closeModal,
+  }
+})

--- a/atable/tests/table.spec.ts
+++ b/atable/tests/table.spec.ts
@@ -5,6 +5,7 @@ import { mount } from '@vue/test-utils'
 import ATable from '../src/components/ATable.vue'
 import data from './data/http_logs.json'
 import type { TableColumn, TableConfig } from '../src/types'
+import { useTableStore, initializeTableStore } from '../src/stores/table'
 
 describe('table component', () => {
 	const columns: TableColumn[] = [
@@ -38,6 +39,7 @@ describe('table component', () => {
 	]
 
 	const defaultProps = {
+		id: 'table1',
 		columns,
 		modelValue: data,
 		config: { view: 'list' } as TableConfig,
@@ -45,6 +47,12 @@ describe('table component', () => {
 
 	beforeEach(() => {
 		setActivePinia(createPinia())
+		initializeTableStore({
+			id: 'table1',
+			columns,
+			rows: data,
+			config: { view: 'list' },
+		})
 	})
 
 	it('verify header row', async () => {
@@ -119,6 +127,7 @@ describe('table component', () => {
 
 		const wrapper = mount(ATable, {
 			props: {
+				id: 'table2',
 				columns,
 				modelValue: data,
 				config: { view: 'list' },
@@ -170,6 +179,7 @@ describe('table component', () => {
 
 		const wrapper = mount(ATable, {
 			props: {
+				id: 'table3',
 				columns,
 				modelValue: data,
 				config: { view: 'list' },
@@ -188,5 +198,17 @@ describe('table component', () => {
 
 		const reportDateCell = dataCells.at(3)
 		expect(reportDateCell!.text()).toBeTruthy()
+	})
+
+	it('verify multiple table instances', async () => {
+		const wrapper1 = mount(ATable, { props: { ...defaultProps, id: 'table1' } })
+		const wrapper2 = mount(ATable, { props: { ...defaultProps, id: 'table2' } })
+
+		expect(wrapper1.vm).toBeTruthy()
+		expect(wrapper2.vm).toBeTruthy()
+
+		const store = useTableStore()
+		expect(store.rows['table1']).toHaveLength(data.length)
+		expect(store.rows['table2']).toHaveLength(data.length)
 	})
 })


### PR DESCRIPTION
Implement a single Pinia store to manage table data for multiple tables.

* **Store Implementation**
  - Add `useTableStore` in `atable/src/stores/table.ts` to manage table data for multiple tables.
  - Define state, getters, and actions for managing table data.
  - Implement functions to get and set cell data, toggle row expansion, and handle modal visibility.

* **Component Updates**
  - Update `ATable.vue` to use the shared table store and manage multiple table instances.
  - Modify `ACell.vue`, `ARow.vue`, `AExpansionRow.vue`, `ATableHeader.vue`, and `ATableModal.vue` to use the shared table store and handle table-specific data using `tableId`.

* **Tests**
  - Update `table.spec.ts` to initialize the shared table store and verify multiple table instances.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/agritheory/stonecrop/pull/232?shareId=89eae492-2cbb-4789-a48b-28937ded7774).