### PR TITLE
[beam] render filter menus over list content

### DIFF
--- a/beam/package.json
+++ b/beam/package.json
@@ -41,6 +41,7 @@
 		"test:ui": "vitest --ui"
 	},
 	"dependencies": {
+		"@vueuse/components": "^12.7.0",
 		"@vueuse/core": "^12.7.0",
 		"mqtt": "^5.10.3",
 		"onscan.js": "^1.5.2",

--- a/beam/src/components/BeamFilter.vue
+++ b/beam/src/components/BeamFilter.vue
@@ -5,7 +5,7 @@
 			<BeamHeading>Filter</BeamHeading>
 		</div>
 
-		<div class="beam_filters-options">
+		<div v-if="isOpen" class="beam_filters-options">
 			<slot></slot>
 		</div>
 	</div>
@@ -45,7 +45,7 @@ const getTotalHeight = (el: HTMLDivElement) => {
 
 <style scoped>
 .beam_filters {
-	overflow: hidden;
+	overflow: visible;
 	box-sizing: border-box;
 	transition: all 0.2s ease-in-out;
 	border-bottom: 1px solid var(--sc-row-border-color);
@@ -68,8 +68,6 @@ const getTotalHeight = (el: HTMLDivElement) => {
 }
 
 .beam_filters-options {
-	/* display: grid;
-	grid-template-columns: repeat(2, 1fr); */
 	display: flex;
 	flex-direction: row;
 	column-gap: 1rem;

--- a/beam/src/components/BeamFilter.vue
+++ b/beam/src/components/BeamFilter.vue
@@ -1,12 +1,12 @@
 <template>
 	<div class="beam_filters">
-		<div @click="toggle" class="beam_filters-heading">
-			<ToggleArrow :open="isOpen" />
+		<div @click="isFilterExpanded = !isFilterExpanded" class="beam_filters-heading">
+			<ToggleArrow :open="isFilterExpanded" />
 			<BeamHeading>Filter</BeamHeading>
 		</div>
 
-		<div v-if="isOpen" class="beam_filters-options">
-			<slot></slot>
+		<div v-show="isFilterExpanded" class="beam_filters-options">
+			<slot />
 		</div>
 	</div>
 </template>
@@ -16,11 +16,7 @@ import { ref } from 'vue'
 
 defineSlots<{ default(): any }>()
 
-const isOpen = ref(false)
-
-const toggle = () => {
-	isOpen.value = !isOpen.value
-}
+const isFilterExpanded = ref(false)
 </script>
 
 <style scoped>

--- a/beam/src/components/BeamFilter.vue
+++ b/beam/src/components/BeamFilter.vue
@@ -46,9 +46,10 @@ const isFilterExpanded = ref(false)
 .beam_filters-options {
 	display: flex;
 	flex-direction: row;
-	justify-content: space-around;
+	justify-content: flex-start;
 	margin: 1rem 0;
 	padding: 0 1rem;
+	gap: 1rem;
 
 	@media (max-width: 479px) {
 		flex-direction: column;

--- a/beam/src/components/BeamFilter.vue
+++ b/beam/src/components/BeamFilter.vue
@@ -46,6 +46,7 @@ const isFilterExpanded = ref(false)
 .beam_filters-options {
 	display: flex;
 	flex-direction: row;
+	justify-content: space-around;
 	margin: 1rem 0;
 	padding: 0 1rem;
 

--- a/beam/src/components/BeamFilter.vue
+++ b/beam/src/components/BeamFilter.vue
@@ -1,6 +1,6 @@
 <template>
-	<div ref="beam-filters" class="beam_filters" :style="{ height: isOpen ? '100%' : headerHeight }">
-		<div ref="beam-filters-header" @click="toggle" class="beam_filters-heading">
+	<div class="beam_filters">
+		<div @click="toggle" class="beam_filters-heading">
 			<ToggleArrow :open="isOpen" />
 			<BeamHeading>Filter</BeamHeading>
 		</div>
@@ -12,55 +12,35 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, useTemplateRef } from 'vue'
+import { ref } from 'vue'
 
 defineSlots<{ default(): any }>()
 
-const header = useTemplateRef('beam-filters-header')
-const beamFilters = useTemplateRef('beam-filters')
-
 const isOpen = ref(false)
-const headerHeight = ref<string>()
-const totalHeight = ref<string>()
 
 const toggle = () => {
 	isOpen.value = !isOpen.value
-}
-
-onMounted(() => {
-	if (header.value && beamFilters.value) {
-		headerHeight.value = getTotalHeight(header.value)
-		totalHeight.value = getTotalHeight(beamFilters.value)
-		beamFilters.value.style.height = headerHeight.value
-	}
-})
-
-const getTotalHeight = (el: HTMLDivElement) => {
-	const height = el.getBoundingClientRect().height
-	const marginTop = parseInt(getComputedStyle(el).marginTop)
-	const marginBottom = parseInt(getComputedStyle(el).marginBottom)
-	return height + marginTop + marginBottom + 'px'
 }
 </script>
 
 <style scoped>
 .beam_filters {
-	overflow: visible;
-	box-sizing: border-box;
-	transition: all 0.2s ease-in-out;
+	background-color: var(--sc-primary-color);
 	border-bottom: 1px solid var(--sc-row-border-color);
-	background: white;
+	box-sizing: border-box;
+	min-height: 2em;
+	overflow: visible;
+	padding: 0.625rem;
+	transition: all 0.2s ease-in-out;
 }
 
 .beam_filters-heading {
-	background: var(--sc-primary-color);
+	align-items: center;
+	background-color: var(--sc-primary-color);
+	box-sizing: border-box;
 	cursor: pointer;
 	display: flex;
-	align-items: center;
-	padding-left: 1rem;
-	box-sizing: border-box;
 	font-size: 1rem;
-	padding: 0 2rem;
 
 	& > h1 {
 		font-size: 1rem;
@@ -68,13 +48,13 @@ const getTotalHeight = (el: HTMLDivElement) => {
 }
 
 .beam_filters-options {
+	background-color: var(--sc-primary-color);
+	box-sizing: border-box;
+	column-gap: 1rem;
 	display: flex;
 	flex-direction: row;
-	column-gap: 1rem;
-	background: white;
-	box-sizing: border-box;
-	padding: 0 1rem;
 	margin: 1rem 0;
+	padding: 0 1rem;
 
 	@media (max-width: 479px) {
 		flex-direction: column;

--- a/beam/src/components/BeamFilterOption.vue
+++ b/beam/src/components/BeamFilterOption.vue
@@ -56,24 +56,24 @@ const selectChoice = (data: BeamFilterChoice) => {
 .beam_filter-option {
 	cursor: pointer;
 	position: relative;
-	margin-bottom: 1rem;
 }
 
 .beam_filter-option-heading {
-	font-size: 1rem;
+	font-size: 1rem !important;
 	padding-bottom: 0.25rem;
 }
 
 .beam_filter-option-select {
-	position: relative;
-	appearance: none;
-	border: 1px solid var(--sc-row-border-color);
-	font-weight: bold;
-	color: var(--sc-primary-text-color);
-	font-size: 0.8rem;
-	font-family: var(--sc-font-family);
-	display: flex;
 	align-items: stretch;
+	appearance: none;
+	background-color: white;
+	border: 1px solid var(--sc-row-border-color);
+	color: var(--sc-primary-text-color);
+	display: flex;
+	font-family: var(--sc-font-family);
+	font-size: 0.8rem;
+	font-weight: bold;
+	position: relative;
 }
 
 label {

--- a/beam/src/components/BeamFilterOption.vue
+++ b/beam/src/components/BeamFilterOption.vue
@@ -104,18 +104,19 @@ svg {
 }
 
 .beam_filter-select-menu {
-	/* position: absolute; */
-	z-index: 100;
+	background-color: white;
 	border-top: none;
-	left: 0;
 	border: 1px solid var(--sc-row-border-color);
-	padding: 0rem;
-	list-style: none;
-	width: 100%;
 	box-sizing: border-box;
+	left: 0;
+	list-style: none;
+	margin: 0;
 	max-height: 200px;
 	overflow-y: scroll;
-	margin: 0;
+	padding: 0rem;
+	position: absolute;
+	width: 100%;
+	z-index: 100;
 }
 
 .beam_filter-select-option {

--- a/beam/src/components/BeamFilterOption.vue
+++ b/beam/src/components/BeamFilterOption.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="beam_filter-container">
+	<div v-on-click-outside="() => (open = false)" class="beam_filter-container">
 		<BeamHeading class="beam_filter-option-heading">{{ title }}</BeamHeading>
 		<div @click="open = !open" class="beam_filter-option">
 			<div class="beam_filter-option-select">
@@ -29,13 +29,12 @@
 </template>
 
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import { ref } from 'vue'
 
 import { BeamFilterChoice } from '../types'
 
-const emit = defineEmits<{
-	select: [choice: BeamFilterChoice]
-}>()
+const emit = defineEmits<{ select: [choice: BeamFilterChoice] }>()
 
 const { title = 'title', choices = [] } = defineProps<{
 	choices: BeamFilterChoice[]

--- a/beam/src/components/BeamFilterOption.vue
+++ b/beam/src/components/BeamFilterOption.vue
@@ -1,7 +1,7 @@
 <template>
-	<div v-on-click-outside="() => (open = false)" class="beam_filter-container">
+	<div v-on-click-outside="() => (isMenuOpen = false)" class="beam_filter-container">
 		<BeamHeading class="beam_filter-option-heading">{{ title }}</BeamHeading>
-		<div @click="open = !open" class="beam_filter-option">
+		<div @click="isMenuOpen = !isMenuOpen" class="beam_filter-option">
 			<div class="beam_filter-option-select">
 				<div class="beam_filter-arrow">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35.36 70.71">
@@ -13,7 +13,7 @@
 				</div>
 			</div>
 
-			<ul ref="menu" v-if="open" class="beam_filter-select-menu">
+			<ul ref="menu" v-if="isMenuOpen" class="beam_filter-select-menu">
 				<li
 					v-for="choice in choices"
 					:class="{ selected: label == choice.label }"
@@ -41,7 +41,7 @@ const { title = 'title', choices = [] } = defineProps<{
 	title?: string
 }>()
 
-const open = ref(false)
+const isMenuOpen = ref(false)
 const label = ref(choices[0].label)
 const value = ref(choices[0].value)
 

--- a/common/changes/@stonecrop/beam/fix-beam-filter-style-1_2025-03-03-10-36.json
+++ b/common/changes/@stonecrop/beam/fix-beam-filter-style-1_2025-03-03-10-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "render filter menus over list content",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
 
   ../../beam:
     dependencies:
+      '@vueuse/components':
+        specifier: ^12.7.0
+        version: 12.7.0(typescript@5.6.3)
       '@vueuse/core':
         specifier: ^12.7.0
         version: 12.7.0(typescript@5.6.3)

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,1 @@
-export default ['aform/*/vite.config.ts', 'atable/*/vite.config.ts']
+export default ['aform/*/vite.config.ts', 'atable/*/vite.config.ts', 'beam/*/vite.config.ts']


### PR DESCRIPTION
Fixes https://github.com/agritheory/beam/pull/260.

---

@agritheory @crabinak I added some minor fixes to get the filters to overlay instead of moving the list content down:
- Set the filter dropdown menus to be `position: absolute;` so that they're outside the normal DOM flow and can be overlayed over other content.
  - However, doing the above makes the filter menus draw over the list content rather than pushing it down, but the menus then stay hidden behind the list content.
- Changed the `overflow` setting for the `beam_filters` container element from `hidden` to `visible` to allow the menus to actually render in front of the list content.
  - However, doing the above _always_ shows the dropdown menus instead of having them only visible behind the filter toggle.
- Modified the top-level options container in `BeamFilter.vue` to only show options content if the section is open.

The `overflow: visible;` setting may have other unintended side-effects as shown by the last change I had to make, but I'm not sure how else to handle this?

---

![image](https://github.com/user-attachments/assets/6c9214bf-21cf-4654-b0f0-c345b1db1156)

![image](https://github.com/user-attachments/assets/63820508-7734-4155-b8ad-4d6f1d9687b9)