### PR TITLE
[beam] ItemCount validation

### DIFF
--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
-import { computed, nextTick, type HTMLAttributes } from 'vue'
+import { computed, type HTMLAttributes } from 'vue'
 
 const count = defineModel<number>({ required: true })
 const {
@@ -33,15 +33,8 @@ const {
 const isCountComplete = computed(() => denominator !== 0 && count.value === denominator)
 
 const validate = (payload: ClipboardEvent | InputEvent | MouseEvent) => {
-	const newValue = Number((payload.target as HTMLElement).innerHTML)
-	if (typeof newValue !== 'number' || isNaN(newValue)) {
-		count.value = count.value || 0
-	} else {
-		count.value = denominator > 0 ? Math.min(newValue, denominator) : newValue
-	}
-	nextTick(() => {
-		;(payload.target as HTMLElement).innerHTML = count.value.toString() || '0'
-	})
+	const newValue = Number((payload.target as HTMLElement).innerHTML) || 0
+	count.value = denominator ? Math.min(newValue, denominator) : newValue
 }
 
 const debouncedRequest = useDebounceFn((payload: InputEvent) => validate(payload), debounce)

--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -35,12 +35,13 @@ const isCountComplete = computed(() => denominator !== 0 && count.value === deno
 const validate = (payload: ClipboardEvent | InputEvent | MouseEvent) => {
 	const newValue = Number((payload.target as HTMLElement).innerHTML)
 	if (typeof newValue !== 'number' || isNaN(newValue)) {
-		nextTick(() => {
-			;(payload.target as HTMLElement).innerHTML = count.value.toString() || '0'
-		})
-		return
+		count.value = count.value || 0
+	} else {
+		count.value = denominator > 0 ? Math.min(newValue, denominator) : newValue
 	}
-	count.value = denominator > 0 ? Math.min(newValue, denominator) : newValue
+	nextTick(() => {
+		;(payload.target as HTMLElement).innerHTML = count.value.toString() || '0'
+	})
 }
 
 const debouncedRequest = useDebounceFn((payload: InputEvent) => validate(payload), debounce)

--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -19,7 +19,7 @@ import { computed, nextTick, type HTMLAttributes } from 'vue'
 
 const count = defineModel<number>({ required: true })
 const {
-	denominator,
+	denominator = 0,
 	debounce = 300,
 	editable = true,
 	uom = '',
@@ -30,7 +30,7 @@ const {
 	uom?: string
 }>()
 
-const isCountComplete = computed(() => count.value === denominator)
+const isCountComplete = computed(() => denominator !== 0 && count.value === denominator)
 
 const validate = (payload: ClipboardEvent | InputEvent | MouseEvent) => {
 	const newValue = Number((payload.target as HTMLElement).innerHTML)

--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -35,18 +35,12 @@ const isCountComplete = computed(() => count.value === denominator)
 const validate = (payload: ClipboardEvent | InputEvent | MouseEvent) => {
 	const newValue = Number((payload.target as HTMLElement).innerHTML)
 	if (typeof newValue !== 'number' || isNaN(newValue)) {
-		count.value = 0
 		nextTick(() => {
-			;(payload.target as HTMLElement).innerHTML = '0'
+			;(payload.target as HTMLElement).innerHTML = count.value.toString() || '0'
 		})
 		return
 	}
-	count.value = Math.min(newValue, denominator)
-	if (denominator > 0) {
-		count.value = Math.min(newValue, denominator)
-	} else {
-		count.value = newValue
-	}
+	count.value = denominator > 0 ? Math.min(newValue, denominator) : newValue
 }
 
 const debouncedRequest = useDebounceFn((payload: InputEvent) => validate(payload), debounce)

--- a/beam/src/components/ItemCount.vue
+++ b/beam/src/components/ItemCount.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
-import { computed, type HTMLAttributes } from 'vue'
+import { computed, nextTick, type HTMLAttributes } from 'vue'
 
 const count = defineModel<number>({ required: true })
 const {
@@ -33,8 +33,20 @@ const {
 const isCountComplete = computed(() => count.value === denominator)
 
 const validate = (payload: ClipboardEvent | InputEvent | MouseEvent) => {
-	const newValue = Number((payload.target as HTMLElement).innerHTML) || 0
+	const newValue = Number((payload.target as HTMLElement).innerHTML)
+	if (typeof newValue !== 'number' || isNaN(newValue)) {
+		count.value = 0
+		nextTick(() => {
+			;(payload.target as HTMLElement).innerHTML = '0'
+		})
+		return
+	}
 	count.value = Math.min(newValue, denominator)
+	if (denominator > 0) {
+		count.value = Math.min(newValue, denominator)
+	} else {
+		count.value = newValue
+	}
 }
 
 const debouncedRequest = useDebounceFn((payload: InputEvent) => validate(payload), debounce)

--- a/common/changes/@stonecrop/beam/fix_edit-item-count-without-denominator_2025-06-13-18-06.json
+++ b/common/changes/@stonecrop/beam/fix_edit-item-count-without-denominator_2025-06-13-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "Modified validation logic in ItemCount.vue to fix \"NaN\" display and update issues in ListView inputs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/examples/beam/data/items.json
+++ b/examples/beam/data/items.json
@@ -3,7 +3,7 @@
 		"barcode": "6281478257437327897",
 		"label": "Item 1 Long Title: Including Subtitle to demonstrate ellipsis",
 		"description": "iPhone this and that",
-		"count": { "count": 0, "of": 3 },
+		"count": { "count": 0 },
 		"linkComponent": "ListAnchor",
 		"route": "/item1"
 	},


### PR DESCRIPTION
While working on a Beam issue, I noticed that in some`ListView` inputs, clicking on them would display a "NaN" value.

Also, when the "denominator" value isn't required, it's not possible to update the input value.

After checking some Stonecrops files, I found that the ItemCount.vue component had a validation rule that was causing these issues. I modified the validations, and now everything works as expected.

## After

https://github.com/user-attachments/assets/90aedbfb-d397-4c57-ba15-e1738eab2814

## Before

https://github.com/user-attachments/assets/9740935d-e7bb-434f-b2e5-5f7e80eac70a

