### PR TITLE
[atable] select all content when a cell is focused

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -27,7 +27,7 @@
 <script setup lang="ts">
 import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
 import { useDebounceFn, useElementBounding } from '@vueuse/core'
-import { computed, type CSSProperties, ref, useTemplateRef } from 'vue'
+import { computed, type CSSProperties, ref, useTemplateRef, nextTick } from 'vue'
 
 import { createTableStore } from '../stores/table'
 import { isHtmlString } from '../utils'
@@ -166,10 +166,17 @@ const selectAllText = () => {
 		// Use the Selection API to select all text content in the contenteditable cell
 		const selection = window.getSelection()
 		if (selection) {
-			const range = document.createRange()
-			range.selectNodeContents(cellRef.value)
-			selection.removeAllRanges()
-			selection.addRange(range)
+			try {
+				const range = document.createRange()
+				if (range.selectNodeContents) {
+					range.selectNodeContents(cellRef.value)
+					selection.removeAllRanges()
+					selection.addRange(range)
+				}
+			} catch (error) {
+				// Fallback for environments where Range API is not fully supported
+				// This is expected in some test environments
+			}
 		}
 	}
 }
@@ -182,11 +189,74 @@ const onFocus = () => {
 	}
 }
 
+const saveCursorPosition = () => {
+	try {
+		const selection = window.getSelection()
+		if (selection && selection.rangeCount > 0 && cellRef.value) {
+			const range = selection.getRangeAt(0)
+			// Save the offset from the start of the cell
+			const preCaretRange = range.cloneRange()
+			if (preCaretRange.selectNodeContents && preCaretRange.setEnd) {
+				preCaretRange.selectNodeContents(cellRef.value)
+				preCaretRange.setEnd(range.endContainer, range.endOffset)
+				return preCaretRange.toString().length
+			}
+		}
+	} catch (error) {
+		// Fallback for environments where Selection API is not fully supported
+	}
+	return 0
+}
+
+const restoreCursorPosition = (position: number) => {
+	if (!cellRef.value) return
+
+	try {
+		const selection = window.getSelection()
+		if (!selection) return
+
+		let charIndex = 0
+		const walker = document.createTreeWalker
+			? document.createTreeWalker(cellRef.value, NodeFilter.SHOW_TEXT, null)
+			: null
+
+		if (!walker) return
+
+		let node: Node | null
+		let range: Range | null = null
+
+		while ((node = walker.nextNode())) {
+			const textNode = node as Text
+			const nextCharIndex = charIndex + textNode.textContent!.length
+
+			if (position <= nextCharIndex) {
+				range = document.createRange()
+				if (range.setStart && range.setEnd) {
+					range.setStart(textNode, position - charIndex)
+					range.setEnd(textNode, position - charIndex)
+					break
+				}
+			}
+			charIndex = nextCharIndex
+		}
+
+		if (range && selection.removeAllRanges && selection.addRange) {
+			selection.removeAllRanges()
+			selection.addRange(range)
+		}
+	} catch (error) {
+		// Fallback for environments where DOM APIs are not fully supported
+	}
+}
+
 const updateCellData = (payload: Event) => {
 	const target = payload.target as HTMLTableCellElement
 	if (target.textContent === currentData.value) {
 		return
 	}
+
+	// Save cursor position before updating
+	const cursorPosition = saveCursorPosition()
 
 	currentData.value = target.textContent!
 
@@ -199,6 +269,11 @@ const updateCellData = (payload: Event) => {
 		cellModified.value = target.textContent !== originalData
 		store.setCellData(colIndex, rowIndex, target.textContent)
 	}
+
+	// Use nextTick to restore cursor position after Vue's reactive updates but before browser repaint
+	void nextTick().then(() => {
+		restoreCursorPosition(cursorPosition)
+	})
 }
 
 const debouncedUpdateCellData = useDebounceFn(updateCellData, debounce)

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -11,7 +11,7 @@
 		@focus="onFocus"
 		@paste="updateCellData"
 		@input="debouncedUpdateCellData"
-		@click="showModal"
+		@click="onCellClick"
 		class="atable-cell"
 		:class="cellClasses">
 		<component
@@ -85,6 +85,14 @@ const cellClasses = computed(() => {
 	}
 })
 
+const onCellClick = () => {
+	// First, select all text if the cell is editable
+	selectAllText()
+
+	// Then handle modal display (original showModal behavior)
+	showModal()
+}
+
 const showModal = () => {
 	const { left, bottom, width, height } = useElementBounding(cellRef)
 
@@ -153,9 +161,24 @@ if (addNavigation) {
 // 	}
 // }
 
+const selectAllText = () => {
+	if (cellRef.value && column.edit) {
+		// Use the Selection API to select all text content in the contenteditable cell
+		const selection = window.getSelection()
+		if (selection) {
+			const range = document.createRange()
+			range.selectNodeContents(cellRef.value)
+			selection.removeAllRanges()
+			selection.addRange(range)
+		}
+	}
+}
+
 const onFocus = () => {
 	if (cellRef.value) {
 		currentData.value = cellRef.value.textContent!
+		// Select all text when the cell receives focus
+		selectAllText()
 	}
 }
 

--- a/atable/tests/cell.spec.ts
+++ b/atable/tests/cell.spec.ts
@@ -156,4 +156,67 @@ describe('table cell component', () => {
 		window.getSelection = originalGetSelection
 		document.createRange = originalCreateRange
 	})
+
+	it('should preserve cursor position during debounced updates', async () => {
+		vi.useFakeTimers()
+
+		// Mock Selection API for cursor position testing
+		const mockRange = {
+			cloneRange: vi.fn(() => ({
+				selectNodeContents: vi.fn(),
+				setEnd: vi.fn(),
+				toString: vi.fn(() => 'test text'),
+			})),
+			endContainer: {} as Node,
+			endOffset: 5,
+		}
+
+		const mockSelection = {
+			rangeCount: 1,
+			getRangeAt: vi.fn(() => mockRange),
+			removeAllRanges: vi.fn(),
+			addRange: vi.fn(),
+		}
+
+		const mockTreeWalker = {
+			nextNode: vi.fn().mockReturnValueOnce({ textContent: 'test text' }).mockReturnValue(null),
+		}
+
+		const originalGetSelection = window.getSelection
+		const originalCreateRange = document.createRange
+		const originalCreateTreeWalker = document.createTreeWalker
+
+		window.getSelection = vi.fn(() => mockSelection)
+		document.createRange = vi.fn(() => ({
+			setStart: vi.fn(),
+			setEnd: vi.fn(),
+		}))
+		document.createTreeWalker = vi.fn(() => mockTreeWalker)
+
+		const wrapper = mount(ATable, { props, global: { components: { ACell } } })
+
+		const dataCells = wrapper.findAllComponents(ACell)
+		const editableCell = dataCells.at(1)
+		expect(editableCell?.exists()).toBe(true)
+
+		// Focus the cell and simulate typing
+		await editableCell!.trigger('focus')
+		editableCell!.element.textContent = 'new text'
+		await editableCell!.trigger('input')
+
+		// Fast-forward time to trigger debounced function
+		vi.advanceTimersByTime(300)
+		await wrapper.vm.$nextTick()
+
+		// Verify that cursor position functions were called
+		expect(mockSelection.getRangeAt).toHaveBeenCalled()
+		expect(mockRange.cloneRange).toHaveBeenCalled()
+
+		// Restore original functions
+		window.getSelection = originalGetSelection
+		document.createRange = originalCreateRange
+		document.createTreeWalker = originalCreateTreeWalker
+
+		vi.useRealTimers()
+	})
 })

--- a/atable/tests/cell.spec.ts
+++ b/atable/tests/cell.spec.ts
@@ -86,4 +86,74 @@ describe('table cell component', () => {
 
 		vi.useRealTimers()
 	})
+
+	it('should select all text content when cell is focused', async () => {
+		// Mock the Selection API
+		const mockSelection = {
+			removeAllRanges: vi.fn(),
+			addRange: vi.fn(),
+		} as unknown as Selection
+		const mockRange = {
+			selectNodeContents: vi.fn(),
+		} as unknown as Range
+
+		const originalGetSelection = window.getSelection
+		const originalCreateRange = document.createRange
+
+		window.getSelection = vi.fn(() => mockSelection)
+		document.createRange = vi.fn(() => mockRange)
+
+		const wrapper = mount(ATable, { props, global: { components: { ACell } } })
+
+		const dataCells = wrapper.findAllComponents(ACell)
+		const editableCell = dataCells.at(1) // This is an editable cell
+		expect(editableCell?.exists()).toBe(true)
+
+		// Trigger focus on an editable cell
+		await editableCell!.trigger('focus')
+
+		// Verify that the Selection API was called to select all text
+		expect(mockRange.selectNodeContents).toHaveBeenCalledWith(editableCell!.element)
+		expect(mockSelection.removeAllRanges).toHaveBeenCalled()
+		expect(mockSelection.addRange).toHaveBeenCalledWith(mockRange)
+
+		// Restore original functions
+		window.getSelection = originalGetSelection
+		document.createRange = originalCreateRange
+	})
+
+	it('should select all text content when editable cell is clicked', async () => {
+		// Mock the Selection API
+		const mockSelection = {
+			removeAllRanges: vi.fn(),
+			addRange: vi.fn(),
+		} as unknown as Selection
+		const mockRange = {
+			selectNodeContents: vi.fn(),
+		} as unknown as Range
+
+		const originalGetSelection = window.getSelection
+		const originalCreateRange = document.createRange
+
+		window.getSelection = vi.fn(() => mockSelection)
+		document.createRange = vi.fn(() => mockRange)
+
+		const wrapper = mount(ATable, { props, global: { components: { ACell } } })
+
+		const dataCells = wrapper.findAllComponents(ACell)
+		const editableCell = dataCells.at(1) // This is an editable cell
+		expect(editableCell?.exists()).toBe(true)
+
+		// Trigger click on an editable cell
+		await editableCell!.trigger('click')
+
+		// Verify that the Selection API was called to select all text
+		expect(mockRange.selectNodeContents).toHaveBeenCalledWith(editableCell!.element)
+		expect(mockSelection.removeAllRanges).toHaveBeenCalled()
+		expect(mockSelection.addRange).toHaveBeenCalledWith(mockRange)
+
+		// Restore original functions
+		window.getSelection = originalGetSelection
+		document.createRange = originalCreateRange
+	})
 })

--- a/common/changes/@stonecrop/atable/fix-cell-focus-select-all_2025-08-06-10-17.json
+++ b/common/changes/@stonecrop/atable/fix-cell-focus-select-all_2025-08-06-10-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "select all text for edit when a cell is focused",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}


### PR DESCRIPTION
Closes https://github.com/agritheory/fab/issues/102.

(The slight jitter after editing the bottom cell is me accidentally using the arrow keys)

[Screencast From 2025-08-06 15-49-51.webm](https://github.com/user-attachments/assets/30bc3e48-8444-42b1-9eea-d1a05729c5c0)
