### PR TITLE
[atable] ACell tests - non-editable cases

### DIFF
--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -250,6 +250,8 @@ const restoreCursorPosition = (position: number) => {
 }
 
 const updateCellData = (payload: Event) => {
+	if (!column.edit) return
+
 	const target = payload.target as HTMLTableCellElement
 	if (target.textContent === currentData.value) {
 		return

--- a/atable/tests/cell.spec.ts
+++ b/atable/tests/cell.spec.ts
@@ -219,4 +219,142 @@ describe('table cell component', () => {
 
 		vi.useRealTimers()
 	})
+
+	describe('ACell - Non-editable behavior', () => {
+		const nonEditableProps = {
+			rows: data,
+			columns,
+			'onUpdate:rows': () => {},
+			config: { view: 'list' } as TableConfig,
+		}
+
+		it('should have correct DOM attributes when column is not editable', async () => {
+			const wrapper = mount(ATable, { props: nonEditableProps, global: { components: { ACell } } })
+
+			const dataCells = wrapper.findAllComponents(ACell)
+			const nonEditableCell = dataCells.at(0) // First column has edit: false
+
+			expect(nonEditableCell?.exists()).toBe(true)
+			expect(nonEditableCell!.element.getAttribute('contenteditable')).toBe('false')
+			expect(nonEditableCell!.element.getAttribute('data-editable')).toBe('false')
+		})
+
+		it('should not select text when non-editable cell is clicked', async () => {
+			// Mock the Selection API
+			const mockSelection = {
+				removeAllRanges: vi.fn(),
+				addRange: vi.fn(),
+			} as unknown as Selection
+			const mockRange = {
+				selectNodeContents: vi.fn(),
+			} as unknown as Range
+
+			const originalGetSelection = window.getSelection
+			const originalCreateRange = document.createRange
+
+			window.getSelection = vi.fn(() => mockSelection)
+			document.createRange = vi.fn(() => mockRange)
+
+			const wrapper = mount(ATable, { props: nonEditableProps, global: { components: { ACell } } })
+
+			const dataCells = wrapper.findAllComponents(ACell)
+			const nonEditableCell = dataCells.at(0) // First column has edit: false
+			expect(nonEditableCell?.exists()).toBe(true)
+
+			// Trigger click on non-editable cell
+			await nonEditableCell!.trigger('click')
+
+			// Verify that the Selection API was NOT called (text should not be selected)
+			expect(mockRange.selectNodeContents).not.toHaveBeenCalled()
+			expect(mockSelection.removeAllRanges).not.toHaveBeenCalled()
+			expect(mockSelection.addRange).not.toHaveBeenCalled()
+
+			// Restore original functions
+			window.getSelection = originalGetSelection
+			document.createRange = originalCreateRange
+		})
+
+		it('should not select text when non-editable cell is focused', async () => {
+			// Mock the Selection API
+			const mockSelection = {
+				removeAllRanges: vi.fn(),
+				addRange: vi.fn(),
+			} as unknown as Selection
+			const mockRange = {
+				selectNodeContents: vi.fn(),
+			} as unknown as Range
+
+			const originalGetSelection = window.getSelection
+			const originalCreateRange = document.createRange
+
+			window.getSelection = vi.fn(() => mockSelection)
+			document.createRange = vi.fn(() => mockRange)
+
+			const wrapper = mount(ATable, { props: nonEditableProps, global: { components: { ACell } } })
+
+			const dataCells = wrapper.findAllComponents(ACell)
+			const nonEditableCell = dataCells.at(0) // First column has edit: false
+			expect(nonEditableCell?.exists()).toBe(true)
+
+			// Trigger focus on non-editable cell
+			await nonEditableCell!.trigger('focus')
+
+			// Verify that the Selection API was not called (text should not be selected)
+			expect(mockRange.selectNodeContents).not.toHaveBeenCalled()
+			expect(mockSelection.removeAllRanges).not.toHaveBeenCalled()
+			expect(mockSelection.addRange).not.toHaveBeenCalled()
+
+			// Restore original functions
+			window.getSelection = originalGetSelection
+			document.createRange = originalCreateRange
+		})
+
+		// TODO: This test reveals a potential bug - non-editable cells should not emit update events
+		// Currently failing because ACell.vue always has @input listeners active regardless of edit state
+		it.skip('should not emit update events when non-editable cell receives input', async () => {
+			vi.useFakeTimers()
+			const onUpdateSpy = vi.fn()
+			const isolatedProps = {
+				rows: [...data],
+				columns,
+				'onUpdate:rows': onUpdateSpy,
+				config: { view: 'list' } as TableConfig,
+			}
+
+			const wrapper = mount(ATable, { props: isolatedProps, global: { components: { ACell } } })
+
+			const dataCells = wrapper.findAllComponents(ACell)
+			const nonEditableCell = dataCells.at(0) // First column has edit: false
+
+			expect(nonEditableCell?.exists()).toBe(true)
+			expect(nonEditableCell!.element.getAttribute('contenteditable')).toBe('false')
+
+			const initialEmittedCount = wrapper.emitted('update:rows')?.length || 0
+			await nonEditableCell!.trigger('input')
+
+			vi.advanceTimersByTime(300)
+			await wrapper.vm.$nextTick()
+
+			// Verify that no new update events were emitted from this specific action
+			const finalEmittedCount = wrapper.emitted('update:rows')?.length || 0
+			expect(finalEmittedCount).toBe(initialEmittedCount)
+			expect(onUpdateSpy).not.toHaveBeenCalled()
+
+			vi.useRealTimers()
+		})
+
+		it('should update currentData when non-editable cell is focused (for navigation)', async () => {
+			const wrapper = mount(ATable, { props: nonEditableProps, global: { components: { ACell } } })
+
+			const dataCells = wrapper.findAllComponents(ACell)
+			const nonEditableCell = dataCells.at(0) // First column has edit: false
+			expect(nonEditableCell?.exists()).toBe(true)
+
+			await nonEditableCell!.trigger('focus')
+
+			// Verify that currentData was updated
+			// Note: This is intentional behavior - focus updates currentData even for non-editable cells
+			expect(nonEditableCell!.vm.currentData).toEqual(nonEditableCell!.text())
+		})
+	})
 })

--- a/atable/tests/cell.spec.ts
+++ b/atable/tests/cell.spec.ts
@@ -197,6 +197,7 @@ describe('table cell component', () => {
 
 		const dataCells = wrapper.findAllComponents(ACell)
 		const editableCell = dataCells.at(1)
+		console.log('editableCell', editableCell)
 		expect(editableCell?.exists()).toBe(true)
 
 		// Focus the cell and simulate typing
@@ -309,9 +310,7 @@ describe('table cell component', () => {
 			document.createRange = originalCreateRange
 		})
 
-		// TODO: This test reveals a potential bug - non-editable cells should not emit update events
-		// Currently failing because ACell.vue always has @input listeners active regardless of edit state
-		it.skip('should not emit update events when non-editable cell receives input', async () => {
+		it('should not emit update events when non-editable cell receives input', async () => {
 			vi.useFakeTimers()
 			const onUpdateSpy = vi.fn()
 			const isolatedProps = {

--- a/common/changes/@stonecrop/atable/issue-206_atable-tests_2025-09-12-17-56.json
+++ b/common/changes/@stonecrop/atable/issue-206_atable-tests_2025-09-12-17-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "Tests ACell added - non-editable cases",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}


### PR DESCRIPTION
https://github.com/agritheory/stonecrop/issues/206

**Non-editable behavior tests:**
1. **DOM attributes** - Validates `contenteditable="false"` and `data-editable="false"`
2. **Click interaction** - Confirms text selection is prevented on click
3. **Focus interaction** - Ensures `selectAllText()` is not called on focus
4. **Navigation state** - Verifies `currentData` updates for consistent navigation
5. **Input events (SKIPPED)** - Identifies potential bug where non-editable cells still process `@input` events

## Input events

The skipped test reveals that `ACell.vue` always has active `@input` listeners regardless of `column.edit` state. Non-editable cells can still emit update events.

Should I..
- Delete the skipped test
- Fix the component listener (add edit state validation)

## Results

<img width="1041" height="366" alt="Screenshot 2025-09-12 at 2 46 49 PM" src="https://github.com/user-attachments/assets/4da3edd4-1050-477d-8d9d-9239907205d3" />

**Any edge cases we should add?**
