### PR TITLE
[graphql][stonecrop] Connection Fix

### DIFF
--- a/common/reviews/api/stonecrop.api.md
+++ b/common/reviews/api/stonecrop.api.md
@@ -282,6 +282,7 @@ export class Stonecrop {
     constructor(registry: Registry);
     addRecord(doctype: string | DoctypeMeta, recordId: string, recordData: any): void;
     clearRecords(doctype: string | DoctypeMeta): void;
+    getMeta(doctype: string): Promise<any>;
     getRecord(doctype: DoctypeMeta, recordId: string): Promise<void>;
     getRecordById(doctype: string | DoctypeMeta, recordId: string): HSTNode | undefined;
     getRecordIds(doctype: string | DoctypeMeta): string[];

--- a/examples/dev-runner.sh
+++ b/examples/dev-runner.sh
@@ -27,12 +27,17 @@ case $EXAMPLE_NAME in
     "desktop")
         PACKAGE_NAME="@stonecrop/desktop"
         ;;
+    "docbuilder")
+        ;;
+    "graphql_client")
+        PACKAGE_NAME="@stonecrop/graphql-client"
+        ;;
     "node_editor")
         PACKAGE_NAME="@stonecrop/node-editor"
         ;;
     *)
         echo "Unknown example: $EXAMPLE_NAME"
-        echo "Available examples: aform, atable, beam, code_editor, desktop, node_editor"
+        echo "Available examples: aform, atable, beam, code_editor, desktop, docbuilder, graphql_client, node_editor"
         exit 1
         ;;
 esac
@@ -44,12 +49,16 @@ if [ ! -d "$EXAMPLE_NAME" ]; then
 fi
 
 # Run concurrently with histoire dev and rush build watch
-if [ "$EXAMPLE_NAME" == "desktop" ]; then
-    npx concurrently --kill-others --names "histoire,rush" \
+if [ "$EXAMPLE_NAME" == "desktop" ] || [ "$EXAMPLE_NAME" == "graphql_client" ]; then
+    npx concurrently --kill-others --names "server,rush" \
     "cd $EXAMPLE_NAME/ && vite dev ./ --config vite.config.ts" \
     "rush build --watch --to $PACKAGE_NAME"
+elif [ "$EXAMPLE_NAME" == "docbuilder" ]; then
+    npx concurrently --kill-others --names "server,rush" \
+    "cd $EXAMPLE_NAME/ && vite dev ./ --config vite.config.ts" \
+    "rush build --watch"
 else
-    npx concurrently --kill-others --names "histoire,rush" \
+    npx concurrently --kill-others --names "server,rush" \
     "cd $EXAMPLE_NAME/ && histoire dev" \
     "rush build --watch --to $PACKAGE_NAME"
 fi

--- a/examples/graphql_client/App.vue
+++ b/examples/graphql_client/App.vue
@@ -27,6 +27,6 @@ const { stonecrop } = useStonecrop()
 onMounted(async () => {
 	const response = await fetch('/schema')
 	schema.value = await response.json()
-	data.value = await stonecrop.value.getMeta({ doctype: 'Issue' })
+	if (stonecrop.value) data.value = await stonecrop.value.getMeta('Issue')
 })
 </script>

--- a/examples/graphql_client/server.ts
+++ b/examples/graphql_client/server.ts
@@ -1,5 +1,5 @@
 import { createGraphQLHandler, mirageGraphQLFieldResolver } from '@miragejs/graphql'
-import typeDefs from '@stonecrop/graphql-client'
+import { typeDefs } from '@stonecrop/graphql-client'
 import { createServer, Model } from 'miragejs'
 
 export function makeServer() {

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,10 +16,10 @@
 		"dev:aform": "./dev-runner.sh aform",
 		"dev:atable": "./dev-runner.sh atable",
 		"dev:beam": "./dev-runner.sh beam",
-		"dev:builder": "vite serve docbuilder/ --config docbuilder/vite.config.ts",
+		"dev:builder": "./dev-runner.sh docbuilder",
 		"dev:code_editor": "./dev-runner.sh code_editor",
 		"dev:desktop": "./dev-runner.sh desktop",
-		"dev:graphql_client": "vite dev graphql_client/ --config graphql_client/vite.config.ts",
+		"dev:graphql_client": "./dev-runner.sh graphql_client",
 		"dev:node_editor": "./dev-runner.sh node_editor"
 	},
 	"dependencies": {

--- a/graphql_client/src/index.ts
+++ b/graphql_client/src/index.ts
@@ -47,6 +47,7 @@ const metaParser = (obj: string): MetaParser => {
 const methods = {
 	getMeta: async (doctype: string, url?: string): Promise<MetaResponse> => {
 		const client = new GraphQLClient(url || '/graphql', {
+			fetch: window.fetch,
 			jsonSerializer: {
 				stringify: obj => JSON.stringify(obj), // process the request object before sending; leave as default JSON
 				parse: metaParser, // process the response meta object

--- a/stonecrop/API.md
+++ b/stonecrop/API.md
@@ -857,6 +857,14 @@ Clear all records for a doctype
 clearRecords(doctype: string | DoctypeMeta): void
 ```
 
+#### getMeta
+
+Get doctype metadata from the registry
+
+```typescript
+getMeta(doctype: string): Promise<any>
+```
+
 #### getRecord
 
 Get single record from server (maintains compatibility)

--- a/stonecrop/src/stonecrop.ts
+++ b/stonecrop/src/stonecrop.ts
@@ -209,6 +209,18 @@ export class Stonecrop {
 	}
 
 	/**
+	 * Get doctype metadata from the registry
+	 * @param doctype - The doctype to get metadata for
+	 * @returns The doctype metadata
+	 */
+	async getMeta(doctype: string): Promise<any> {
+		if (!this.registry.getMeta) {
+			throw new Error('No getMeta function provided to Registry')
+		}
+		return await this.registry.getMeta(doctype)
+	}
+
+	/**
 	 * Get the root HST store node for advanced usage
 	 * @returns Root HST node
 	 */


### PR DESCRIPTION
## WIP

- `getMeta` method added to Stonecrop Class
- General fixes to use Stonecrop Class from Graphql Client Example.
- `fetch` key added to allow Mirage connection.

### About fetch:

I encountered this error:

<img width="1689" height="1012" alt="Screenshot 2025-10-02 at 10 58 40 AM" src="https://github.com/user-attachments/assets/0fed02e7-11d9-4b4a-8d10-6c418cb5fe1f" />

Adding the fetch key allowed Mirage to connect to `GraphQLClient`

## Next Step.

https://github.com/agritheory/stonecrop/issues/264
