### PR TITLE
script

### DIFF
--- a/aform/package.json
+++ b/aform/package.json
@@ -39,7 +39,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs aform",
+		"docs": "bash ../common/scripts/run-docs.sh aform",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"test": "vitest run --coverage.enabled false",

--- a/atable/package.json
+++ b/atable/package.json
@@ -42,7 +42,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs atable",
+		"docs": "bash ../common/scripts/run-docs.sh atable",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"test": "vitest run --coverage.enabled false",

--- a/beam/package.json
+++ b/beam/package.json
@@ -41,7 +41,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs beam",
+		"docs": "bash ../common/scripts/run-docs.sh beam",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"test": "vitest run --coverage.enabled false",

--- a/code_editor/package.json
+++ b/code_editor/package.json
@@ -34,7 +34,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs code_editor",
+		"docs": "bash ../common/scripts/run-docs.sh code_editor",
 		"lint": "eslint .",
 		"preview": "vite preview"
 	},

--- a/common/changes/@stonecrop/aform/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/aform/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/atable/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/atable/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/common/changes/@stonecrop/beam/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/beam/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/common/changes/@stonecrop/code-editor/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/code-editor/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/code-editor",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/code-editor"
+}

--- a/common/changes/@stonecrop/desktop/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/desktop/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/desktop",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/desktop"
+}

--- a/common/changes/@stonecrop/graphql-client/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/graphql-client/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-client",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-client"
+}

--- a/common/changes/@stonecrop/node-editor/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/node-editor/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/node-editor",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/node-editor"
+}

--- a/common/changes/@stonecrop/stonecrop/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/stonecrop/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/changes/@stonecrop/utilities/doc-tools-dependencies_2025-11-14-09-21.json
+++ b/common/changes/@stonecrop/utilities/doc-tools-dependencies_2025-11-14-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/utilities",
+      "comment": "update docs script",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/utilities"
+}

--- a/common/scripts/run-docs.sh
+++ b/common/scripts/run-docs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Wrapper script to generate documentation
+# Automatically installs doc-tools autoinstaller if needed
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+DOC_TOOLS_DIR="$REPO_ROOT/common/autoinstallers/doc-tools"
+
+if [ ! -d "$DOC_TOOLS_DIR/node_modules" ]; then
+  cd "$DOC_TOOLS_DIR"
+  pnpm install --silent
+fi
+
+cd "$DOC_TOOLS_DIR"
+node generate-docs.mjs "$1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -39,7 +39,7 @@
 		"_phase:build": "heft build && vite build && rushx docs",
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs desktop",
+		"docs": "bash ../common/scripts/run-docs.sh desktop",
 		"lint": "eslint ."
 	},
 	"dependencies": {

--- a/graphql_client/package.json
+++ b/graphql_client/package.json
@@ -38,7 +38,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs graphql_client",
+		"docs": "bash ../common/scripts/run-docs.sh graphql_client",
 		"lint": "eslint .",
 		"preview": "vite preview"
 	},

--- a/node_editor/package.json
+++ b/node_editor/package.json
@@ -40,7 +40,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs node_editor",
+		"docs": "bash ../common/scripts/run-docs.sh node_editor",
 		"lint": "eslint .",
 		"preview": "vite preview"
 	},

--- a/stonecrop/package.json
+++ b/stonecrop/package.json
@@ -38,7 +38,7 @@
 		"_phase:build": "heft build && vite build && rushx docs",
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs stonecrop",
+		"docs": "bash ../common/scripts/run-docs.sh stonecrop",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"test": "vitest run --coverage.enabled false",

--- a/utilities/package.json
+++ b/utilities/package.json
@@ -38,7 +38,7 @@
 		"prepublish": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"dev": "vite",
-		"docs": "cd ../common/autoinstallers/doc-tools && node generate-docs.mjs utilities",
+		"docs": "bash ../common/scripts/run-docs.sh utilities",
 		"lint": "eslint .",
 		"preview": "vite preview"
 	},


### PR DESCRIPTION
# Issue

When I clone **Stonecrop** for the first time and install the base dependencies — `pnpm`, `rush`, and `node v22` — then execute the commands mentioned in the README:

```sh
cd stonecrop
rush update
rush rebuild
```
I get some errors.

I noticed that Curtis ran into the same errors too: https://github.com/agritheory/stonecrop/issues/258#issuecomment-3344981122

## Before

<img width="1079" height="951" alt="Screenshot 2025-11-13 at 4 02 19 PM" src="https://github.com/user-attachments/assets/0f818063-240a-48fa-b913-42c675539597" />

<img width="1323" height="954" alt="Screenshot 2025-11-13 at 4 02 39 PM" src="https://github.com/user-attachments/assets/8e6ead16-7cd2-4495-9a8f-473a0a2c4b14" />

## After
<img width="1325" height="1001" alt="Screenshot 2025-11-13 at 4 04 03 PM" src="https://github.com/user-attachments/assets/821d5b19-8a58-47a7-9626-ccde6982c412" />

<img width="905" height="1009" alt="Screenshot 2025-11-13 at 4 07 29 PM" src="https://github.com/user-attachments/assets/c5ddf09f-8196-4db6-949b-337e122a0868" />

Now, when you clone the repo for the first time, the script run-docs.sh verifies that the doc-tools package has its dependencies installed.