### PR TITLE
[grafserv] set non-workspace dependencies for nuxt-grafserv

### DIFF
--- a/common/changes/@stonecrop/nuxt-grafserv/fix-grafserv-deps_2026-02-02-05-51.json
+++ b/common/changes/@stonecrop/nuxt-grafserv/fix-grafserv-deps_2026-02-02-05-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/nuxt-grafserv",
+      "comment": "update peer dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/nuxt-grafserv"
+}

--- a/nuxt_grafserv/package.json
+++ b/nuxt_grafserv/package.json
@@ -85,8 +85,8 @@
 		"vue-tsc": "^3.2.2"
 	},
 	"peerDependencies": {
-		"@stonecrop/casl-middleware": "workspace:*",
-		"@stonecrop/rockfoil": "workspace:*",
+		"@stonecrop/casl-middleware": "*",
+		"@stonecrop/rockfoil": "*",
 		"postgraphile": "^5.0.0-rc.4",
 		"graphile-config": "^1.0.0-rc.3"
 	},


### PR DESCRIPTION
Replaces `workspace:` dependency formats with something that's more appropriate for peer dependencies