### PR TITLE
[aform] separate schema and data layer

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -79,7 +79,7 @@ HST Store
 - Field types: Data, Select, Currency, Quantity, Date, etc.
 - Validation and masking support
 - Nested fieldsets and tables within forms
-- Read-only and edit modes
+- Multi-mode forms: `edit` (fully interactive), `read` (disabled inputs), `display` (visual-only)
 
 #### 3. `@stonecrop/atable` (Table Components)
 **Purpose**: Advanced data table with spreadsheet-like functionality

--- a/aform/api.md
+++ b/aform/api.md
@@ -122,6 +122,7 @@ Basic field structure for AForm schemas
 export type BaseSchema = {
     fieldname: string;
     component?: string;
+    mode?: FormMode;
 };
 ```
 
@@ -137,7 +138,7 @@ export type ComponentProps = {
     label?: string;
     mask?: string;
     required?: boolean;
-    readOnly?: boolean;
+    mode?: FormMode;
     uuid?: string;
     validation?: {
         errorMessage: string;
@@ -158,7 +159,6 @@ export type DoctypeSchema = BaseSchema & {
     options: string;
     label?: string;
     schema?: SchemaTypes[];
-    readOnly?: boolean;
 };
 ```
 
@@ -174,6 +174,16 @@ export type FieldsetSchema = BaseSchema & {
     schema?: (FormSchema | TableSchema)[];
     collapsible?: boolean;
 };
+```
+
+### FormMode
+
+The rendering mode for AForm components
+
+**Definition:**
+
+```typescript
+export type FormMode = 'edit' | 'read' | 'display';
 ```
 
 ### FormSchema
@@ -218,7 +228,6 @@ export type TableDoctypeSchema = BaseSchema & {
     columns?: TableColumn[];
     config?: TableConfig;
     rows?: TableRow[];
-    readOnly?: boolean;
 };
 ```
 

--- a/aform/api.md
+++ b/aform/api.md
@@ -122,7 +122,6 @@ Basic field structure for AForm schemas
 export type BaseSchema = {
     fieldname: string;
     component?: string;
-    value?: any;
 };
 ```
 

--- a/aform/eslint.config.js
+++ b/aform/eslint.config.js
@@ -29,7 +29,7 @@ export default defineConfig(
 			},
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['tests/**/*.ts', 'tests/**/*.spec.ts'],
+					allowDefaultProject: ['tests/*.ts'],
 				},
 				tsconfigRootDir: import.meta.dirname,
 				extraFileExtensions: ['.vue'],

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -10,9 +10,9 @@
 				</h4>
 				<AForm
 					:data="nestedData[componentObj.fieldname]"
-					@update:data="val => updateNestedData(componentObj.fieldname, val)"
+					:mode="resolvedMode(componentObj)"
 					:schema="componentObj.schema"
-					:mode="resolvedMode(componentObj)" />
+					@update:data="val => updateNestedData(componentObj.fieldname, val)" />
 			</div>
 
 			<!-- Regular field -->
@@ -36,7 +36,7 @@ import type { SchemaTypes, FormMode } from '../types'
 
 const emit = defineEmits(['update:schema', 'update:data'])
 const dataModel = defineModel<Record<string, any>>('data', { required: true })
-const { schema, mode } = defineProps<{ schema: SchemaTypes[]; mode?: FormMode }>()
+const { schema, mode = 'edit' } = defineProps<{ schema: SchemaTypes[]; mode?: FormMode }>()
 
 // Reactive nested data refs for two-way binding with nested AForm instances
 const nestedData = ref<Record<string, any>>({})
@@ -80,7 +80,7 @@ const componentProps = (componentObj: SchemaTypes) => {
 		// handle ATable data formats in case the table is nested under an AForm;
 		// when resolveSchema sets rows: [], this fallback routes data from dataModel[fieldname]
 		if (key === 'rows') {
-			if (!value || (Array.isArray(value) && (value as any[]).length === 0)) {
+			if (!value || (Array.isArray(value) && value.length === 0)) {
 				propsToPass['rows'] = dataModel.value[componentObj.fieldname] || []
 			}
 		}
@@ -92,7 +92,7 @@ const effectiveFormMode = computed<FormMode>(() => mode ?? 'edit')
 
 // Resolve the effective mode for a schema field, allowing per-field overrides
 function resolvedMode(componentObj: SchemaTypes): FormMode {
-	const fieldMode = (componentObj as any).mode as FormMode | undefined
+	const fieldMode = componentObj.mode
 	if (fieldMode) return fieldMode
 	return effectiveFormMode.value
 }

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -64,21 +64,9 @@ const updateNestedData = (fieldname: string, val: any) => {
 	nestedData.value[fieldname] = val
 	if (dataModel.value) {
 		dataModel.value[fieldname] = val
-		emit('update:data', dataModel.value)
+		emit('update:data', { ...dataModel.value })
 	}
 }
-
-// Sync data values into schema immediately and on changes
-watchEffect(() => {
-	if (dataModel.value && schema) {
-		// Sync data values into schema
-		schema.forEach(field => {
-			if (field.fieldname && dataModel.value[field.fieldname] !== undefined) {
-				field.value = dataModel.value[field.fieldname]
-			}
-		})
-	}
-})
 
 const componentProps = (componentObj: SchemaTypes) => {
 	const propsToPass: Record<string, any> = {}
@@ -107,21 +95,16 @@ watchEffect(() => {
 
 	// Recreate cache only if length changed
 	if (childModelsCache.value.length !== schema.length) {
-		childModelsCache.value = schema.map((val, i) => {
+		childModelsCache.value = schema.map((_val, i) => {
 			return computed({
 				get() {
-					return val.value
+					return dataModel.value?.[schema[i].fieldname]
 				},
 				set: newValue => {
 					const fieldname = schema[i].fieldname
-					// Find the component in schema and update it
-					// eslint-disable-next-line vue/no-mutating-props
-					schema[i].value = newValue
-					// Also sync to data model for two-way binding
 					if (fieldname && dataModel.value) {
 						dataModel.value[fieldname] = newValue
-						// Manually emit to trigger parent's update:data handler
-						emit('update:data', dataModel.value)
+						emit('update:data', { ...dataModel.value })
 					}
 					emit('update:schema', schema)
 				},

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -12,7 +12,7 @@
 					:data="nestedData[componentObj.fieldname]"
 					@update:data="val => updateNestedData(componentObj.fieldname, val)"
 					:schema="componentObj.schema"
-					:read-only="readOnly || (componentObj as any).readOnly" />
+					:mode="resolvedMode(componentObj)" />
 			</div>
 
 			<!-- Regular field -->
@@ -22,7 +22,7 @@
 				v-model="childModels[key].value"
 				:schema="componentObj"
 				:data="dataModel[componentObj.fieldname]"
-				:read-only="readOnly"
+				:mode="resolvedMode(componentObj)"
 				v-bind="componentProps(componentObj)">
 			</component>
 		</template>
@@ -32,11 +32,11 @@
 <script setup lang="ts">
 import { computed, watchEffect, watch, ref } from 'vue'
 
-import type { SchemaTypes } from '../types'
+import type { SchemaTypes, FormMode } from '../types'
 
 const emit = defineEmits(['update:schema', 'update:data'])
 const dataModel = defineModel<Record<string, any>>('data', { required: true })
-const { schema, readOnly } = defineProps<{ schema: SchemaTypes[]; readOnly?: boolean }>()
+const { schema, mode } = defineProps<{ schema: SchemaTypes[]; mode?: FormMode }>()
 
 // Reactive nested data refs for two-way binding with nested AForm instances
 const nestedData = ref<Record<string, any>>({})
@@ -71,7 +71,9 @@ const updateNestedData = (fieldname: string, val: any) => {
 const componentProps = (componentObj: SchemaTypes) => {
 	const propsToPass: Record<string, any> = {}
 	for (const [key, value] of Object.entries(componentObj)) {
-		if (!['component', 'fieldtype'].includes(key)) {
+		// 'mode' is excluded here because it is handled by resolvedMode()
+		// and passed explicitly via :mode to avoid conflicting with the form-level defaults.
+		if (!['component', 'fieldtype', 'mode'].includes(key)) {
 			propsToPass[key] = value
 		}
 
@@ -84,6 +86,15 @@ const componentProps = (componentObj: SchemaTypes) => {
 		}
 	}
 	return propsToPass
+}
+
+const effectiveFormMode = computed<FormMode>(() => mode ?? 'edit')
+
+// Resolve the effective mode for a schema field, allowing per-field overrides
+function resolvedMode(componentObj: SchemaTypes): FormMode {
+	const fieldMode = (componentObj as any).mode as FormMode | undefined
+	if (fieldMode) return fieldMode
+	return effectiveFormMode.value
 }
 
 // Create stable computed refs array to avoid recreation on every access
@@ -144,6 +155,14 @@ const childModels = computed(() => childModelsCache.value)
 }
 .aform_input-field:focus {
 	outline: 1px solid var(--sc-input-active-border-color);
+}
+
+.aform_display-value {
+	display: block;
+	padding: 0.5rem;
+	min-height: 2rem;
+	color: var(--sc-cell-text-color);
+	word-break: break-word;
 }
 
 .aform_input-field:focus + .aform_field-label {

--- a/aform/src/components/form/ACheckbox.vue
+++ b/aform/src/components/form/ACheckbox.vue
@@ -1,16 +1,22 @@
 <template>
 	<div class="aform_form-element">
-		<label class="aform_field-label" :for="uuid">{{ label }}</label>
-		<span class="aform_checkbox-container aform_input-field">
-			<input
-				:id="uuid"
-				v-model="checkbox"
-				type="checkbox"
-				class="aform_checkbox"
-				:readonly="readOnly"
-				:required="required" />
-		</span>
-		<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		<template v-if="mode === 'display'">
+			<label class="aform_field-label">{{ label }}</label>
+			<span class="aform_display-value">{{ checkbox ? '✓' : '✗' }}</span>
+		</template>
+		<template v-else>
+			<label class="aform_field-label" :for="uuid">{{ label }}</label>
+			<span class="aform_checkbox-container aform_input-field">
+				<input
+					:id="uuid"
+					v-model="checkbox"
+					type="checkbox"
+					class="aform_checkbox"
+					:disabled="mode === 'read'"
+					:required="required" />
+			</span>
+			<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		</template>
 	</div>
 </template>
 
@@ -19,7 +25,7 @@ import { InputHTMLAttributes } from 'vue'
 
 import { ComponentProps } from '../../types'
 
-const { label, required, readOnly, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
+const { label, required, mode, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
 const checkbox = defineModel<InputHTMLAttributes['checked']>()
 </script>
 

--- a/aform/src/components/form/AComboBox.vue
+++ b/aform/src/components/form/AComboBox.vue
@@ -9,6 +9,9 @@
 </template>
 
 <script setup lang="ts">
+import type { ComponentProps } from '../../types'
+
 // TODO: change props from individual elements to the store object
-defineProps(['event', 'cellData', 'tableID'])
+// TODO: implement full mode/display support
+defineProps<ComponentProps & { event?: any; cellData?: any; tableID?: string }>()
 </script>

--- a/aform/src/components/form/ADate.vue
+++ b/aform/src/components/form/ADate.vue
@@ -1,15 +1,21 @@
 <template>
 	<div>
-		<input
-			:id="uuid"
-			ref="date"
-			v-model="inputDate"
-			type="date"
-			:disabled="readOnly"
-			:required="required"
-			@click="showPicker" />
-		<label :for="uuid">{{ label }}</label>
-		<p v-show="validation.errorMessage" v-html="validation.errorMessage"></p>
+		<template v-if="mode === 'display'">
+			<span class="aform_display-value">{{ inputDate ? new Date(inputDate).toLocaleDateString() : '' }}</span>
+			<label>{{ label }}</label>
+		</template>
+		<template v-else>
+			<input
+				:id="uuid"
+				ref="date"
+				v-model="inputDate"
+				type="date"
+				:disabled="mode === 'read'"
+				:required="required"
+				@click="showPicker" />
+			<label :for="uuid">{{ label }}</label>
+			<p v-show="validation.errorMessage" v-html="validation.errorMessage"></p>
+		</template>
 	</div>
 </template>
 
@@ -18,13 +24,7 @@ import { useTemplateRef } from 'vue'
 
 import { ComponentProps } from '../../types'
 
-const {
-	label = 'Date',
-	required,
-	readOnly,
-	uuid,
-	validation = { errorMessage: '&nbsp;' },
-} = defineProps<ComponentProps>()
+const { label = 'Date', required, mode, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
 
 const inputDate = defineModel<string | number | Date>({
 	// format the date to be compatible with the native input datepicker

--- a/aform/src/components/form/ADatePicker.vue
+++ b/aform/src/components/form/ADatePicker.vue
@@ -1,5 +1,9 @@
 <template>
-	<div ref="datepicker" class="adatepicker" tabindex="0">
+	<template v-if="mode === 'display' || mode === 'read'">
+		<span class="aform_display-value">{{ date ? new Date(date).toLocaleDateString() : '' }}</span>
+		<label v-if="label">{{ label }}</label>
+	</template>
+	<div v-else ref="datepicker" class="adatepicker" tabindex="0">
 		<table>
 			<tbody>
 				<tr>
@@ -43,8 +47,12 @@
 import { defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
 import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 
+import type { ComponentProps } from '../../types'
+
 const numberOfRows = 6
 const numberOfColumns = 7
+
+const { mode, label } = defineProps<ComponentProps>()
 
 const date = defineModel<number | Date>({ default: new Date() })
 const selectedDate = ref(new Date(date.value))

--- a/aform/src/components/form/ADropdown.vue
+++ b/aform/src/components/form/ADropdown.vue
@@ -1,9 +1,14 @@
 <template>
-	<div v-on-click-outside="onClickOutside" class="autocomplete" :class="{ isOpen: dropdown.open }">
+	<div v-if="mode === 'display'" class="input-wrapper">
+		<span class="aform_display-value">{{ search ?? '' }}</span>
+		<label>{{ label }}</label>
+	</div>
+	<div v-else v-on-click-outside="onClickOutside" class="autocomplete" :class="{ isOpen: dropdown.open }">
 		<div class="input-wrapper">
 			<input
 				v-model="search"
 				type="text"
+				:disabled="mode === 'read'"
 				@input="filter"
 				@focus="openDropdown"
 				@keydown.down="selectNextResult"
@@ -33,17 +38,21 @@
 import { vOnClickOutside } from '@vueuse/components'
 import { reactive } from 'vue'
 
+import type { ComponentProps } from '../../types'
+
 const {
 	label,
 	items = [],
 	isAsync = false,
 	filterFunction = undefined,
-} = defineProps<{
-	label: string
-	items?: string[]
-	isAsync?: boolean
-	filterFunction?: (search: string) => string[] | Promise<string[]>
-}>()
+	mode,
+} = defineProps<
+	ComponentProps & {
+		items?: string[]
+		isAsync?: boolean
+		filterFunction?: (search: string) => string[] | Promise<string[]>
+	}
+>()
 const search = defineModel<string>()
 
 const dropdown = reactive({

--- a/aform/src/components/form/AFieldset.vue
+++ b/aform/src/components/form/AFieldset.vue
@@ -5,7 +5,7 @@
 			<CollapseButton v-if="collapsible" :collapsed="collapsed" />
 		</legend>
 		<slot :collapsed="collapsed">
-			<AForm v-show="!collapsed" :schema="formSchema" v-model:data="formData" :mode="mode" />
+			<AForm v-show="!collapsed" v-model:data="formData" :schema="formSchema" :mode="mode" />
 		</slot>
 	</fieldset>
 </template>
@@ -22,7 +22,7 @@ const {
 	label,
 	collapsible,
 	data = {},
-	mode,
+	mode = 'edit',
 } = defineProps<{
 	schema: SchemaTypes[]
 	label: string

--- a/aform/src/components/form/AFieldset.vue
+++ b/aform/src/components/form/AFieldset.vue
@@ -5,7 +5,7 @@
 			<CollapseButton v-if="collapsible" :collapsed="collapsed" />
 		</legend>
 		<slot :collapsed="collapsed">
-			<AForm v-show="!collapsed" :schema="formSchema" v-model:data="formData" />
+			<AForm v-show="!collapsed" :schema="formSchema" v-model:data="formData" :mode="mode" :read-only="readOnly" />
 		</slot>
 	</fieldset>
 </template>
@@ -15,18 +15,24 @@ import { ref } from 'vue'
 
 import CollapseButton from '../base/CollapseButton.vue'
 import AForm from '../AForm.vue'
-import { SchemaTypes } from '../../types'
+import type { SchemaTypes, FormMode } from '../../types'
 
 const {
 	schema,
 	label,
 	collapsible,
 	data = {},
+	mode,
+	readOnly,
 } = defineProps<{
 	schema: SchemaTypes[]
 	label: string
 	collapsible?: boolean
 	data?: Record<string, any>
+	/** Rendering mode forwarded to the inner AForm */
+	mode?: FormMode
+	/** @deprecated Use mode instead */
+	readOnly?: boolean
 }>()
 
 const collapsed = ref(false)

--- a/aform/src/components/form/AFieldset.vue
+++ b/aform/src/components/form/AFieldset.vue
@@ -5,7 +5,7 @@
 			<CollapseButton v-if="collapsible" :collapsed="collapsed" />
 		</legend>
 		<slot :collapsed="collapsed">
-			<AForm v-show="!collapsed" :schema="formSchema" v-model:data="formData" :mode="mode" :read-only="readOnly" />
+			<AForm v-show="!collapsed" :schema="formSchema" v-model:data="formData" :mode="mode" />
 		</slot>
 	</fieldset>
 </template>
@@ -23,7 +23,6 @@ const {
 	collapsible,
 	data = {},
 	mode,
-	readOnly,
 } = defineProps<{
 	schema: SchemaTypes[]
 	label: string
@@ -31,8 +30,6 @@ const {
 	data?: Record<string, any>
 	/** Rendering mode forwarded to the inner AForm */
 	mode?: FormMode
-	/** @deprecated Use mode instead */
-	readOnly?: boolean
 }>()
 
 const collapsed = ref(false)

--- a/aform/src/components/form/AFileAttach.vue
+++ b/aform/src/components/form/AFileAttach.vue
@@ -1,20 +1,32 @@
 <template>
 	<div class="aform_form-element aform_file-attach aform__grid--full">
-		<template v-if="files">
-			<div class="aform_file-attach-feedback">
-				<p>
-					You have selected: <b>{{ fileLengthText }}</b>
-				</p>
-				<li v-for="file of files" :key="file.name">
-					{{ file.name }}
-				</li>
-			</div>
+		<template v-if="mode === 'display'">
+			<template v-if="files">
+				<div class="aform_file-attach-feedback">
+					<p>
+						<b>{{ fileLengthText }}</b>
+					</p>
+					<li v-for="file of files" :key="file.name">{{ file.name }}</li>
+				</div>
+			</template>
+			<span v-else class="aform_display-value">No file selected</span>
 		</template>
-
-		<button type="button" class="aform_form-btn" @click="open()">
-			{{ label }}
-		</button>
-		<button type="button" :disabled="!files" class="aform_form-btn" @click="reset()">Reset</button>
+		<template v-else>
+			<template v-if="files">
+				<div class="aform_file-attach-feedback">
+					<p>
+						You have selected: <b>{{ fileLengthText }}</b>
+					</p>
+					<li v-for="file of files" :key="file.name">
+						{{ file.name }}
+					</li>
+				</div>
+			</template>
+			<button type="button" class="aform_form-btn" :disabled="mode === 'read'" @click="open()">
+				{{ label }}
+			</button>
+			<button type="button" :disabled="!files || mode === 'read'" class="aform_form-btn" @click="reset()">Reset</button>
+		</template>
 	</div>
 </template>
 
@@ -22,11 +34,14 @@
 import { useFileDialog } from '@vueuse/core'
 import { computed } from 'vue'
 
-const { label } = defineProps<{ label: string }>()
+import type { ComponentProps } from '../../types'
+
+const { label, mode } = defineProps<ComponentProps>()
 const { files, open, reset, onChange } = useFileDialog()
 
 const fileLengthText = computed(() => {
-	return `${files.value.length} ${files.value.length === 1 ? 'file' : 'files'}`
+	const count = files.value?.length ?? 0
+	return `${count} ${count === 1 ? 'file' : 'files'}`
 })
 
 onChange(files => files)

--- a/aform/src/components/form/ANumericInput.vue
+++ b/aform/src/components/form/ANumericInput.vue
@@ -1,20 +1,26 @@
 <template>
 	<div class="aform_form-element">
-		<input
-			:id="uuid"
-			v-model="inputNumber"
-			class="aform_input-field"
-			type="number"
-			:disabled="readOnly"
-			:required="required" />
-		<label class="aform_field-label" :for="uuid">{{ label }}</label>
-		<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		<template v-if="mode === 'display'">
+			<span class="aform_display-value">{{ inputNumber ?? '' }}</span>
+			<label class="aform_field-label">{{ label }}</label>
+		</template>
+		<template v-else>
+			<input
+				:id="uuid"
+				v-model="inputNumber"
+				class="aform_input-field"
+				type="number"
+				:disabled="mode === 'read'"
+				:required="required" />
+			<label class="aform_field-label" :for="uuid">{{ label }}</label>
+			<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		</template>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { ComponentProps } from '../../types'
 
-const { label, required, readOnly, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
+const { label, required, mode, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
 const inputNumber = defineModel<number>()
 </script>

--- a/aform/src/components/form/ATextInput.vue
+++ b/aform/src/components/form/ATextInput.vue
@@ -1,15 +1,21 @@
 <template>
 	<div class="aform_form-element">
-		<input
-			:id="uuid"
-			v-model="inputText"
-			v-mask="mask"
-			class="aform_input-field"
-			:disabled="readOnly"
-			:maxlength="mask ? (maskFilled ? mask.length : undefined) : undefined"
-			:required="required" />
-		<label class="aform_field-label" :for="uuid">{{ label }} </label>
-		<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		<template v-if="mode === 'display'">
+			<span class="aform_display-value">{{ inputText ?? '' }}</span>
+			<label class="aform_field-label">{{ label }}</label>
+		</template>
+		<template v-else>
+			<input
+				:id="uuid"
+				v-model="inputText"
+				v-mask="mask"
+				class="aform_input-field"
+				:disabled="mode === 'read'"
+				:maxlength="mask ? (maskFilled ? mask.length : undefined) : undefined"
+				:required="required" />
+			<label class="aform_field-label" :for="uuid">{{ label }} </label>
+			<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
+		</template>
 	</div>
 </template>
 
@@ -19,7 +25,7 @@ import { /* inject, */ ref } from 'vue'
 import { useStringMask as vMask } from '../../directives/mask'
 import { ComponentProps } from '../../types'
 
-const { label, mask, required, readOnly, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
+const { label, mask, required, mode, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
 
 // TODO: setup maskFilled as a computed property
 const maskFilled = ref(true)

--- a/aform/src/types/index.ts
+++ b/aform/src/types/index.ts
@@ -77,12 +77,6 @@ export type BaseSchema = {
 	 * @public
 	 */
 	component?: string
-
-	/**
-	 * A placeholder value for the field
-	 * @beta
-	 */
-	value?: any
 }
 
 /**

--- a/aform/src/types/index.ts
+++ b/aform/src/types/index.ts
@@ -1,6 +1,12 @@
 import type { TableColumn, TableConfig, TableRow } from '@stonecrop/atable'
 
 /**
+ * The rendering mode for AForm components
+ * @public
+ */
+export type FormMode = 'edit' | 'read' | 'display'
+
+/**
  * Defined props for AForm components
  * @public
  */
@@ -30,10 +36,10 @@ export type ComponentProps = {
 	required?: boolean
 
 	/**
-	 * Indicate whether elements inside the component are read-only
+	 * The rendering mode for the component
 	 * @public
 	 */
-	readOnly?: boolean
+	mode?: FormMode
 
 	/**
 	 * Set a unique identifier for elements inside the component
@@ -77,6 +83,12 @@ export type BaseSchema = {
 	 * @public
 	 */
 	component?: string
+
+	/**
+	 * Per-field rendering mode override; takes precedence over the AForm-level `mode` prop
+	 * @public
+	 */
+	mode?: FormMode
 }
 
 /**
@@ -226,12 +238,6 @@ export type DoctypeSchema = BaseSchema & {
 	 * @public
 	 */
 	schema?: SchemaTypes[]
-
-	/**
-	 * Indicate whether the nested form is read-only
-	 * @public
-	 */
-	readOnly?: boolean
 }
 
 /**
@@ -285,12 +291,6 @@ export type TableDoctypeSchema = BaseSchema & {
 	 * @public
 	 */
 	rows?: TableRow[]
-
-	/**
-	 * Indicate whether the table is read-only
-	 * @public
-	 */
-	readOnly?: boolean
 }
 
 /**

--- a/aform/tests/checkbox.spec.ts
+++ b/aform/tests/checkbox.spec.ts
@@ -17,4 +17,21 @@ describe('checkbox component', () => {
 		expect(updateEvents![0]).toEqual([true])
 		expect(updateEvents![1]).toEqual([false])
 	})
+
+	it('is disabled in read mode', () => {
+		const w = mount(ACheckbox, { props: { mode: 'read' } })
+		expect(w.find('input').attributes()).toHaveProperty('disabled')
+	})
+
+	it('renders checked value in display mode', () => {
+		const w = mount(ACheckbox, { props: { mode: 'display', modelValue: true } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.text()).toContain('✓')
+	})
+
+	it('renders unchecked value in display mode', () => {
+		const w = mount(ACheckbox, { props: { mode: 'display', modelValue: false } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.text()).toContain('✗')
+	})
 })

--- a/aform/tests/date.spec.ts
+++ b/aform/tests/date.spec.ts
@@ -41,4 +41,26 @@ describe('date component', () => {
 		await $input.trigger('click')
 		expect($input.element.showPicker).toBeUndefined()
 	})
+
+	it('formats date value on input change', async () => {
+		const wrapper = mount(ADate)
+		const $input = wrapper.find('input')
+		await $input.setValue('2023-06-15')
+		await wrapper.vm.$nextTick()
+		expect(($input.element as HTMLInputElement).value).toBe('2023-06-15')
+	})
+
+	it('renders in display mode with formatted date', () => {
+		const wrapper = mount(ADate, {
+			props: { modelValue: '2021-01-01', mode: 'display' },
+		})
+		expect(wrapper.find('input').exists()).toBe(false)
+		expect(wrapper.find('.aform_display-value').exists()).toBe(true)
+	})
+
+	it('renders in display mode with empty span when no value', () => {
+		const wrapper = mount(ADate, { props: { mode: 'display' } })
+		expect(wrapper.find('input').exists()).toBe(false)
+		expect(wrapper.find('.aform_display-value').text()).toBe('')
+	})
 })

--- a/aform/tests/date.spec.ts
+++ b/aform/tests/date.spec.ts
@@ -25,7 +25,7 @@ describe('date component', () => {
 	it('date input is disabled by default', async () => {
 		const wrapper = mount(ADate, {
 			props: {
-				readOnly: true,
+				mode: 'read',
 			},
 		})
 

--- a/aform/tests/datepicker.spec.ts
+++ b/aform/tests/datepicker.spec.ts
@@ -93,4 +93,31 @@ describe('datepicker component', () => {
 
 		expect(wrapper.vm.currentYear).toBe(new Date().getFullYear() + 1)
 	})
+
+	it('renders in read mode as a span', () => {
+		const testDate = new Date(2023, 5, 15)
+		const wrapper = mount(ADatePicker, {
+			props: { mode: 'read', modelValue: testDate },
+		})
+		expect(wrapper.find('.adatepicker').exists()).toBe(false)
+		expect(wrapper.find('.aform_display-value').exists()).toBe(true)
+	})
+
+	it('renders empty span in read mode when no date value', () => {
+		const wrapper = mount(ADatePicker, { props: { mode: 'read' } })
+		expect(wrapper.find('.adatepicker').exists()).toBe(false)
+	})
+
+	it('focuses today when selected date is outside current month view', async () => {
+		const outOfMonthDate = new Date()
+		outOfMonthDate.setMonth(outOfMonthDate.getMonth() + 2)
+		const wrapper = mount(ADatePicker, {
+			attachTo: document.body,
+			props: { modelValue: outOfMonthDate },
+		})
+		await wrapper.vm.$nextTick()
+		// calendar shows future month; neither selectedDate nor todaysDate branches fire —
+		// just verify the component mounts without error
+		expect(wrapper.vm).toBeTruthy()
+	})
 })

--- a/aform/tests/dropdown.spec.ts
+++ b/aform/tests/dropdown.spec.ts
@@ -278,4 +278,35 @@ describe('dropdown input component', () => {
 
 		expect(wrapper.vm).toBeTruthy()
 	})
+
+	it('pressing up with no selection jumps to last item', async () => {
+		const wrapper = mount(ADropdown, {
+			props: { modelValue: '', label: dropdownData.label, items: dropdownData.items },
+		})
+
+		const input = wrapper.find('input')
+		await input.trigger('focus')
+		await input.setValue('')
+		await flushPromises()
+		await wrapper.vm.$nextTick()
+
+		// activeItemIndex is null; pressing Up should set it to last index
+		await input.trigger('keydown.up')
+		await input.trigger('keydown.enter')
+		await wrapper.vm.$nextTick()
+
+		const updateEvents = wrapper.emitted('update:modelValue')
+		expect(updateEvents).toBeTruthy()
+		// last item in ['Apple', 'Orange', 'Pear', 'Kiwi', 'Grape'] is 'Grape'
+		const lastEvent = updateEvents![updateEvents!.length - 1]
+		expect(lastEvent).toEqual(['Grape'])
+	})
+
+	it('renders in display mode as text without input', () => {
+		const wrapper = mount(ADropdown, {
+			props: { modelValue: 'Apple', label: dropdownData.label, items: dropdownData.items, mode: 'display' },
+		})
+		expect(wrapper.find('input').exists()).toBe(false)
+		expect(wrapper.find('.aform_display-value').text()).toBe('Apple')
+	})
 })

--- a/aform/tests/fileattach.spec.ts
+++ b/aform/tests/fileattach.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import AFileAttach from '../src/components/form/AFileAttach.vue'
+
+describe('file attach component', () => {
+	it('renders attach and reset buttons by default', () => {
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File' },
+		})
+		const buttons = wrapper.findAll('button')
+		expect(buttons.length).toBe(2)
+		expect(buttons[0].text()).toContain('Attach File')
+		expect(buttons[1].text()).toContain('Reset')
+	})
+
+	it('reset button is disabled when no file is selected', () => {
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File' },
+		})
+		const resetBtn = wrapper.findAll('button')[1]
+		expect(resetBtn.attributes()).toHaveProperty('disabled')
+	})
+
+	it('both buttons are disabled in read mode', () => {
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'read' },
+		})
+		const buttons = wrapper.findAll('button')
+		expect(buttons[0].attributes()).toHaveProperty('disabled')
+		expect(buttons[1].attributes()).toHaveProperty('disabled')
+	})
+
+	it('renders display mode with no-file message when no file selected', () => {
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'display' },
+		})
+		expect(wrapper.find('button').exists()).toBe(false)
+		expect(wrapper.find('.aform_display-value').text()).toBe('No file selected')
+	})
+})

--- a/aform/tests/form.spec.ts
+++ b/aform/tests/form.spec.ts
@@ -82,7 +82,7 @@ describe('AForm Component', () => {
 		expect(wrapperWithData.vm).toBeTruthy()
 	})
 
-	it('should handle readonly prop', () => {
+	it('should handle mode prop', () => {
 		const readonlyWrapper = mount(AForm, {
 			props: {
 				schema: [
@@ -94,7 +94,7 @@ describe('AForm Component', () => {
 					},
 				] as SchemaTypes[],
 				data: {},
-				readOnly: true,
+				mode: 'read',
 			},
 			components: {
 				ATextInput,

--- a/aform/tests/form.spec.ts
+++ b/aform/tests/form.spec.ts
@@ -83,7 +83,7 @@ describe('AForm Component', () => {
 	})
 
 	it('should handle mode prop', () => {
-		const readonlyWrapper = mount(AForm, {
+		const modeWrapper = mount(AForm, {
 			props: {
 				schema: [
 					{
@@ -101,6 +101,6 @@ describe('AForm Component', () => {
 			},
 		})
 
-		expect(readonlyWrapper.vm).toBeTruthy()
+		expect(modeWrapper.vm).toBeTruthy()
 	})
 })

--- a/aform/tests/form.spec.ts
+++ b/aform/tests/form.spec.ts
@@ -29,19 +29,9 @@ describe('AForm Component', () => {
 		await aTextInputWrapper.find('input').setValue('Steve')
 		await wrapper.vm.$nextTick()
 
-		const updateEvents = wrapper.emitted('update:schema')
-		expect(updateEvents).toBeTruthy()
-		expect(updateEvents![0]).toEqual([
-			[
-				{
-					fieldname: 'first_name',
-					fieldtype: 'Data',
-					component: 'ATextInput',
-					label: 'First Name',
-					value: 'Steve',
-				},
-			],
-		])
+		const updateDataEvents = wrapper.emitted('update:data')
+		expect(updateDataEvents).toBeTruthy()
+		expect((updateDataEvents![updateDataEvents!.length - 1][0] as Record<string, any>).first_name).toBe('Steve')
 	})
 
 	it('should handle componentProps with rows data for nested tables', () => {

--- a/aform/tests/nested-form.spec.ts
+++ b/aform/tests/nested-form.spec.ts
@@ -297,7 +297,7 @@ describe('AForm Nested Schema Rendering', () => {
 	})
 
 	it('passes per-field mode to nested AForm', async () => {
-		const schemaWithReadOnly: SchemaTypes[] = [
+		const schemaWithMode: SchemaTypes[] = [
 			{
 				fieldname: 'name',
 				fieldtype: 'Data',
@@ -316,7 +316,7 @@ describe('AForm Nested Schema Rendering', () => {
 
 		const wrapper = mount(AForm, {
 			props: {
-				schema: schemaWithReadOnly,
+				schema: schemaWithMode,
 				data: {
 					name: 'John',
 					address: { street: '123 Main St', city: 'Springfield' },

--- a/aform/tests/nested-form.spec.ts
+++ b/aform/tests/nested-form.spec.ts
@@ -271,7 +271,7 @@ describe('AForm Nested Schema Rendering', () => {
 		expect(nestedSections.length).toBe(0)
 	})
 
-	it('passes readOnly to nested AForm', async () => {
+	it('passes mode to nested AForm', async () => {
 		const wrapper = mount(AForm, {
 			props: {
 				schema: nestedSchema,
@@ -279,7 +279,7 @@ describe('AForm Nested Schema Rendering', () => {
 					name: 'John',
 					address: { street: '123 Main St', city: 'Springfield' },
 				},
-				readOnly: true,
+				mode: 'read',
 			},
 			global: {
 				components: { ATextInput },
@@ -289,14 +289,14 @@ describe('AForm Nested Schema Rendering', () => {
 		await wrapper.vm.$nextTick()
 		await flushPromises()
 
-		// The nested AForm should receive readOnly
+		// The nested AForm should receive mode
 		const nestedForms = wrapper.findAllComponents(AForm)
 		if (nestedForms.length > 1) {
-			expect(nestedForms[1].props('readOnly')).toBe(true)
+			expect(nestedForms[1].props('mode')).toBe('read')
 		}
 	})
 
-	it('passes per-field readOnly to nested AForm', async () => {
+	it('passes per-field mode to nested AForm', async () => {
 		const schemaWithReadOnly: SchemaTypes[] = [
 			{
 				fieldname: 'name',
@@ -309,7 +309,7 @@ describe('AForm Nested Schema Rendering', () => {
 				fieldtype: 'Doctype',
 				options: 'address',
 				label: 'Address',
-				readOnly: true,
+				mode: 'read',
 				schema: addressSchema,
 			},
 		] as SchemaTypes[]
@@ -330,10 +330,10 @@ describe('AForm Nested Schema Rendering', () => {
 		await wrapper.vm.$nextTick()
 		await flushPromises()
 
-		// The nested AForm should receive readOnly from the field
+		// The nested AForm should receive mode from the field
 		const nestedForms = wrapper.findAllComponents(AForm)
 		if (nestedForms.length > 1) {
-			expect(nestedForms[1].props('readOnly')).toBe(true)
+			expect(nestedForms[1].props('mode')).toBe('read')
 		}
 	})
 

--- a/aform/tests/numeric.spec.ts
+++ b/aform/tests/numeric.spec.ts
@@ -17,4 +17,21 @@ describe('numeric input component', () => {
 		expect(updateEvents).toHaveLength(1)
 		expect(updateEvents![0]).toEqual([26])
 	})
+
+	it('is disabled in read mode', () => {
+		const w = mount(ANumericInput, { props: { modelValue: 42, label: 'Amount', mode: 'read' } })
+		expect(w.find('input').attributes()).toHaveProperty('disabled')
+	})
+
+	it('renders value in display mode without input', () => {
+		const w = mount(ANumericInput, { props: { modelValue: 42, label: 'Amount', mode: 'display' } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.find('.aform_display-value').text()).toBe('42')
+	})
+
+	it('renders empty string in display mode when no value', () => {
+		const w = mount(ANumericInput, { props: { label: 'Amount', mode: 'display' } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.find('.aform_display-value').text()).toBe('')
+	})
 })

--- a/aform/tests/text.spec.ts
+++ b/aform/tests/text.spec.ts
@@ -59,4 +59,21 @@ describe('text input component', () => {
 		expect(updateEvents).toHaveLength(1)
 		expect(updateEvents![0]).toEqual(['Jane'])
 	})
+
+	it('is disabled in read mode', () => {
+		const w = mount(ATextInput, { props: { label: 'Name', modelValue: 'John', mode: 'read' } })
+		expect(w.find('input').attributes()).toHaveProperty('disabled')
+	})
+
+	it('renders value in display mode without input', () => {
+		const w = mount(ATextInput, { props: { label: 'Name', modelValue: 'John', mode: 'display' } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.find('.aform_display-value').text()).toBe('John')
+	})
+
+	it('renders empty string in display mode when no value', () => {
+		const w = mount(ATextInput, { props: { label: 'Name', mode: 'display' } })
+		expect(w.find('input').exists()).toBe(false)
+		expect(w.find('.aform_display-value').text()).toBe('')
+	})
 })

--- a/atable/eslint.config.js
+++ b/atable/eslint.config.js
@@ -29,7 +29,7 @@ export default defineConfig(
 			},
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['tests/**/*.ts', 'tests/**/*.spec.ts'],
+					allowDefaultProject: ['tests/*.ts', 'tests/gantt/*.ts'],
 				},
 				tsconfigRootDir: import.meta.dirname,
 				extraFileExtensions: ['.vue'],

--- a/beam/eslint.config.js
+++ b/beam/eslint.config.js
@@ -35,7 +35,7 @@ export default defineConfig(
 			},
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['tests/**/*.ts', 'tests/**/*.spec.ts'],
+					allowDefaultProject: ['tests/*.ts', 'tests/components/*.ts', 'tests/composables/*.ts'],
 				},
 				tsconfigRootDir: import.meta.dirname,
 			},

--- a/common/changes/@stonecrop/aform/fix-aform-issues_2026-03-11-10-13.json
+++ b/common/changes/@stonecrop/aform/fix-aform-issues_2026-03-11-10-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "separate data layer from the schema",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/aform/fix-aform-issues_2026-03-11-10-48.json
+++ b/common/changes/@stonecrop/aform/fix-aform-issues_2026-03-11-10-48.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@stonecrop/aform",
-      "comment": "separate data layer from the schema",
-      "type": "minor"
+      "comment": "update eslint config",
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/aform"

--- a/common/changes/@stonecrop/atable/fix-aform-issues_2026-03-11-10-47.json
+++ b/common/changes/@stonecrop/atable/fix-aform-issues_2026-03-11-10-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "update eslint config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/common/changes/@stonecrop/beam/fix-aform-issues_2026-03-11-10-47.json
+++ b/common/changes/@stonecrop/beam/fix-aform-issues_2026-03-11-10-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/beam",
+      "comment": "update eslint config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/beam"
+}

--- a/common/changes/@stonecrop/desktop/fix-aform-issues_2026-03-11-10-13.json
+++ b/common/changes/@stonecrop/desktop/fix-aform-issues_2026-03-11-10-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/desktop",
+      "comment": "adopt new AForm API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/desktop"
+}

--- a/common/changes/@stonecrop/desktop/fix-aform-issues_2026-03-11-10-48.json
+++ b/common/changes/@stonecrop/desktop/fix-aform-issues_2026-03-11-10-48.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@stonecrop/desktop",
-      "comment": "adopt new AForm API",
-      "type": "minor"
+      "comment": "update eslint config",
+      "type": "patch"
     }
   ],
   "packageName": "@stonecrop/desktop"

--- a/common/changes/@stonecrop/graphql-client/fix-aform-issues_2026-03-11-10-47.json
+++ b/common/changes/@stonecrop/graphql-client/fix-aform-issues_2026-03-11-10-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-client",
+      "comment": "update eslint config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-client"
+}

--- a/common/changes/@stonecrop/stonecrop/fix-aform-issues_2026-03-11-10-13.json
+++ b/common/changes/@stonecrop/stonecrop/fix-aform-issues_2026-03-11-10-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "add guard for value changes in HST",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/changes/@stonecrop/stonecrop/fix-aform-issues_2026-03-11-10-48.json
+++ b/common/changes/@stonecrop/stonecrop/fix-aform-issues_2026-03-11-10-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "update eslint config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -13,7 +13,7 @@
 		"definitionName": "lockStepVersion",
 		"policyName": "stonecrop",
 		"version": "0.9.2",
-		"nextBump": "patch"
+		"nextBump": "minor"
 	}
 	// {
 	//   /**

--- a/common/reviews/api/aform.api.md
+++ b/common/reviews/api/aform.api.md
@@ -44,6 +44,7 @@ export { ATextInput }
 export type BaseSchema = {
     fieldname: string;
     component?: string;
+    mode?: FormMode;
 };
 
 // @public
@@ -52,7 +53,7 @@ export type ComponentProps = {
     label?: string;
     mask?: string;
     required?: boolean;
-    readOnly?: boolean;
+    mode?: FormMode;
     uuid?: string;
     validation?: {
         errorMessage: string;
@@ -66,7 +67,6 @@ export type DoctypeSchema = BaseSchema & {
     options: string;
     label?: string;
     schema?: SchemaTypes[];
-    readOnly?: boolean;
 };
 
 // @public
@@ -75,6 +75,9 @@ export type FieldsetSchema = BaseSchema & {
     schema?: (FormSchema | TableSchema)[];
     collapsible?: boolean;
 };
+
+// @public
+export type FormMode = 'edit' | 'read' | 'display';
 
 // @public
 export type FormSchema = BaseSchema & {
@@ -103,7 +106,6 @@ export type TableDoctypeSchema = BaseSchema & {
     columns?: TableColumn[];
     config?: TableConfig;
     rows?: TableRow[];
-    readOnly?: boolean;
 };
 
 // @public

--- a/common/reviews/api/aform.api.md
+++ b/common/reviews/api/aform.api.md
@@ -44,7 +44,6 @@ export { ATextInput }
 export type BaseSchema = {
     fieldname: string;
     component?: string;
-    value?: any;
 };
 
 // @public

--- a/desktop/src/components/Desktop.vue
+++ b/desktop/src/components/Desktop.vue
@@ -4,7 +4,7 @@
 		<ActionSet :elements="actionElements" @action-click="handleActionClick" />
 
 		<!-- Main content using AForm -->
-		<AForm v-if="writableSchema.length > 0" v-model="writableSchema" :data="currentViewData" />
+		<AForm v-if="currentViewSchema.length > 0" :schema="currentViewSchema" v-model:data="currentViewData" />
 		<div v-else-if="!stonecrop" class="loading"><p>Initializing Stonecrop...</p></div>
 		<div v-else class="loading">
 			<p>Loading {{ currentView }} data...</p>
@@ -760,54 +760,6 @@ const currentViewSchema = computed<SchemaTypes[]>(() => {
 			return []
 	}
 })
-
-// Writable schema for AForm v-model binding
-const writableSchema = ref<SchemaTypes[]>([])
-
-// Sync computed schema to writable schema when it changes
-watch(
-	currentViewSchema,
-	newSchema => {
-		writableSchema.value = [...newSchema]
-	},
-	{ immediate: true, deep: true }
-)
-
-// Watch for field changes in writable schema and sync to HST
-watch(
-	writableSchema,
-	newSchema => {
-		if (!stonecrop.value || !currentDoctype.value || !currentRecordId.value || isNewRecord.value) {
-			return
-		}
-
-		try {
-			const hstStore = stonecrop.value.getStore()
-
-			// Process form field updates from schema
-			newSchema.forEach(field => {
-				// Only process fields that have a fieldname and value (form fields)
-				if (
-					field.fieldname &&
-					'value' in field &&
-					!['header', 'actions', 'loading', 'error'].includes(field.fieldname)
-				) {
-					const fieldPath = `${currentDoctype.value}.${currentRecordId.value}.${field.fieldname}`
-					const currentValue = hstStore.has(fieldPath) ? hstStore.get(fieldPath) : undefined
-
-					// Only update if value actually changed to avoid infinite loops
-					if (currentValue !== field.value) {
-						hstStore.set(fieldPath, field.value)
-					}
-				}
-			})
-		} catch (error) {
-			// eslint-disable-next-line no-console
-			console.warn('HST schema sync failed:', error)
-		}
-	},
-	{ deep: true }
-)
 
 // Action handlers (will be triggered by button clicks in the UI)
 const handleSave = async () => {

--- a/desktop/src/components/Desktop.vue
+++ b/desktop/src/components/Desktop.vue
@@ -4,7 +4,7 @@
 		<ActionSet :elements="actionElements" @action-click="handleActionClick" />
 
 		<!-- Main content using AForm -->
-		<AForm v-if="currentViewSchema.length > 0" :schema="currentViewSchema" v-model:data="currentViewData" />
+		<AForm v-if="currentViewSchema.length > 0" v-model:data="currentViewData" :schema="currentViewSchema" />
 		<div v-else-if="!stonecrop" class="loading"><p>Initializing Stonecrop...</p></div>
 		<div v-else class="loading">
 			<p>Loading {{ currentView }} data...</p>
@@ -412,7 +412,7 @@ const loadDoctypeMetadata = (doctype: string) => {
 	// The router should have already loaded the metadata, but this ensures the HST structure exists
 	try {
 		stonecrop.value.records(doctype)
-	} catch (error) {
+	} catch {
 		// Silent error handling - structure will be created if needed
 	}
 }
@@ -430,15 +430,6 @@ const getDoctypesSchema = (): SchemaTypes[] => {
 	}))
 
 	return [
-		{
-			fieldname: 'header',
-			component: 'div',
-			value: `
-				<div class="view-header">
-					<h1>Available Doctypes</h1>
-				</div>
-			`,
-		},
 		{
 			fieldname: 'doctypes_table',
 			component: 'ATable',
@@ -492,33 +483,9 @@ const getRecordsSchema = (): SchemaTypes[] => {
 	const records = getRecords()
 	const columns = getColumns()
 
-	// If no columns are available, show a loading or empty state
+	// If no columns are available, let the template fallback handle the loading state
 	if (columns.length === 0) {
-		return [
-			{
-				fieldname: 'header',
-				component: 'div',
-				value: `
-					<div class="view-header">
-						<nav class="breadcrumbs">
-							<a href="/">Home</a>
-							<span class="separator">/</span>
-							<span class="current">${formatDoctypeName(routeDoctype.value || currentDoctype.value)}</span>
-						</nav>
-						<h1>${formatDoctypeName(routeDoctype.value || currentDoctype.value)} Records</h1>
-					</div>
-				`,
-			},
-			{
-				fieldname: 'loading',
-				component: 'div',
-				value: `
-					<div class="loading-state">
-						<p>Loading ${formatDoctypeName(routeDoctype.value || currentDoctype.value)} schema...</p>
-					</div>
-				`,
-			},
-		]
+		return []
 	}
 
 	const rows = records.map((record: any) => ({
@@ -530,74 +497,32 @@ const getRecordsSchema = (): SchemaTypes[] => {
 
 	return [
 		{
-			fieldname: 'header',
-			component: 'div',
-			value: `
-				<div class="view-header">
-					<nav class="breadcrumbs">
-						<a href="/">Home</a>
-						<span class="separator">/</span>
-						<span class="current">${formatDoctypeName(routeDoctype.value || currentDoctype.value)}</span>
-					</nav>
-					<h1>${formatDoctypeName(routeDoctype.value || currentDoctype.value)} Records</h1>
-				</div>
-			`,
+			fieldname: 'records_table',
+			component: 'ATable',
+			columns: [
+				...columns.map(col => ({
+					label: col.label,
+					name: col.fieldname,
+					fieldtype: col.fieldtype,
+					align: 'left',
+					edit: false,
+					width: '20ch',
+				})),
+				{
+					label: 'Actions',
+					name: 'actions',
+					fieldtype: 'Data',
+					align: 'center',
+					edit: false,
+					width: '20ch',
+				},
+			] as TableColumn[],
+			config: {
+				view: 'list',
+				fullWidth: true,
+			} as TableConfig,
+			rows,
 		},
-		{
-			fieldname: 'actions',
-			component: 'div',
-			value: `
-				<div class="view-actions">
-					<button class="btn-primary" data-action="create">
-						New ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}
-					</button>
-				</div>
-			`,
-		},
-		...(records.length === 0
-			? [
-					{
-						fieldname: 'empty_state',
-						component: 'div',
-						value: `
-							<div class="empty-state">
-								<p>No ${routeDoctype.value || currentDoctype.value} records found.</p>
-								<button class="btn-primary" data-action="create">
-									Create First Record
-								</button>
-							</div>
-						`,
-					},
-			  ]
-			: [
-					{
-						fieldname: 'records_table',
-						component: 'ATable',
-						columns: [
-							...columns.map(col => ({
-								label: col.label,
-								name: col.fieldname,
-								fieldtype: col.fieldtype,
-								align: 'left',
-								edit: false,
-								width: '20ch',
-							})),
-							{
-								label: 'Actions',
-								name: 'actions',
-								fieldtype: 'Data',
-								align: 'center',
-								edit: false,
-								width: '20ch',
-							},
-						] as TableColumn[],
-						config: {
-							view: 'list',
-							fullWidth: true,
-						} as TableConfig,
-						rows,
-					},
-			  ]),
 	]
 }
 
@@ -610,101 +535,14 @@ const getRecordFormSchema = (): SchemaTypes[] => {
 		const meta = registry?.registry[currentDoctype.value]
 
 		if (!meta?.schema) {
-			// Return loading state if schema isn't available yet
-			return [
-				{
-					fieldname: 'header',
-					component: 'div',
-					value: `
-						<div class="view-header">
-							<nav class="breadcrumbs">
-								<a href="/">Home</a>
-								<span class="separator">/</span>
-								<a href="/${routeDoctype.value || currentDoctype.value}">${formatDoctypeName(
-						routeDoctype.value || currentDoctype.value
-					)}</a>
-								<span class="separator">/</span>
-								<span class="current">${isNewRecord.value ? 'New Record' : currentRecordId.value}</span>
-							</nav>
-							<h1>${
-								isNewRecord.value
-									? `New ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}`
-									: `Edit ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}`
-							}</h1>
-						</div>
-					`,
-				},
-				{
-					fieldname: 'loading',
-					component: 'div',
-					value: `
-						<div class="loading-state">
-							<p>Loading ${formatDoctypeName(routeDoctype.value || currentDoctype.value)} form...</p>
-						</div>
-					`,
-				},
-			]
+			// Let the template fallback handle the loading state
+			return []
 		}
 
-		const schemaArray = 'toArray' in meta.schema ? meta.schema.toArray() : meta.schema
-		const currentRecord = getCurrentRecord()
-
-		return [
-			{
-				fieldname: 'header',
-				component: 'div',
-				value: `
-					<div class="view-header">
-						<nav class="breadcrumbs">
-							<a href="/">Home</a>
-							<span class="separator">/</span>
-							<a href="/${routeDoctype.value || currentDoctype.value}">${formatDoctypeName(
-					routeDoctype.value || currentDoctype.value
-				)}</a>
-							<span class="separator">/</span>
-							<span class="current">${isNewRecord.value ? 'New Record' : currentRecordId.value}</span>
-						</nav>
-						<h1>
-							${
-								isNewRecord.value
-									? `New ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}`
-									: `Edit ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}`
-							}
-						</h1>
-					</div>
-				`,
-			},
-			{
-				fieldname: 'actions',
-				component: 'div',
-				value: `
-					<div class="view-actions">
-						<button class="btn-primary" data-action="save" ${saving.value ? 'disabled' : ''}>
-							${saving.value ? 'Saving...' : 'Save'}
-						</button>
-						<button class="btn-secondary" data-action="cancel">Cancel</button>
-						${!isNewRecord.value ? '<button class="btn-danger" data-action="delete">Delete</button>' : ''}
-					</div>
-				`,
-			},
-			...schemaArray.map(field => ({
-				...field,
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				value: currentRecord[field.fieldname] || '',
-			})),
-		]
-	} catch (error) {
-		return [
-			{
-				fieldname: 'error',
-				component: 'div',
-				value: `
-					<div class="error-state">
-						<p>Unable to load form schema for ${formatDoctypeName(routeDoctype.value || currentDoctype.value)}</p>
-					</div>
-				`,
-			},
-		]
+		// Data is provided via v-model:data="currentViewData" — no need to spread values into schema
+		return 'toArray' in meta.schema ? meta.schema.toArray() : meta.schema
+	} catch {
+		return []
 	}
 }
 
@@ -739,18 +577,11 @@ const getColumns = () => {
 				fieldtype: ('fieldtype' in field && field.fieldtype) || 'Data',
 			}))
 		}
-	} catch (error) {
+	} catch {
 		// Error getting schema - return empty array
 	}
 
 	return []
-}
-
-const getCurrentRecord = () => {
-	if (!stonecrop.value || !currentDoctype.value || isNewRecord.value) return {}
-
-	const record = stonecrop.value.getRecordById(currentDoctype.value, currentRecordId.value)
-	return record?.get('') || {}
 }
 
 // Schema for different views - defined here after all helper functions are available
@@ -769,7 +600,6 @@ const currentViewSchema = computed<SchemaTypes[]>(() => {
 
 // Action handlers (will be triggered by button clicks in the UI)
 const handleSave = async () => {
-	// eslint-disable-next-line no-console
 	if (!stonecrop.value) return
 
 	saving.value = true
@@ -808,7 +638,7 @@ const handleSave = async () => {
 				})
 			}
 		}
-	} catch (error) {
+	} catch {
 		// Silently handle error
 	} finally {
 		saving.value = false
@@ -836,8 +666,7 @@ const handleCancel = async () => {
 	}
 }
 
-const handleActionClick = (label: string, action: (() => void | Promise<void>) | undefined) => {
-	// eslint-disable-next-line no-console
+const handleActionClick = (_label: string, action: (() => void | Promise<void>) | undefined) => {
 	if (action) {
 		void action()
 	}

--- a/desktop/src/components/Desktop.vue
+++ b/desktop/src/components/Desktop.vue
@@ -60,7 +60,10 @@ const currentViewData = computed<Record<string, any>>({
 
 		try {
 			const record = stonecrop.value.getRecordById(currentDoctype.value, currentRecordId.value)
-			return record?.get('') || {}
+			// Return a plain shallow copy so AForm mutations don't propagate directly into
+			// the HST reactive object, which would bypass field-trigger diffing and cause
+			// setupDeepReactivity to fire triggers for all fields on every keystroke.
+			return { ...(record?.get('') || {}) }
 		} catch {
 			return {}
 		}
@@ -71,11 +74,14 @@ const currentViewData = computed<Record<string, any>>({
 		}
 
 		try {
-			// Update each field in HST, which will automatically trigger field actions
+			// Only update fields that actually changed to avoid triggering actions for unchanged fields
 			const hstStore = stonecrop.value.getStore()
 			for (const [fieldname, value] of Object.entries(newData)) {
 				const fieldPath = `${currentDoctype.value}.${currentRecordId.value}.${fieldname}`
-				hstStore.set(fieldPath, value)
+				const currentValue = hstStore.has(fieldPath) ? hstStore.get(fieldPath) : undefined
+				if (currentValue !== value) {
+					hstStore.set(fieldPath, value)
+				}
 			}
 		} catch (error) {
 			// eslint-disable-next-line no-console

--- a/docs/reference/aform.md
+++ b/docs/reference/aform.md
@@ -127,7 +127,7 @@ Basic field structure for AForm schemas
 export type BaseSchema = {
     fieldname: string;
     component?: string;
-    value?: any;
+    mode?: FormMode;
 };
 ```
 
@@ -143,7 +143,7 @@ export type ComponentProps = {
     label?: string;
     mask?: string;
     required?: boolean;
-    readOnly?: boolean;
+    mode?: FormMode;
     uuid?: string;
     validation?: {
         errorMessage: string;
@@ -164,7 +164,6 @@ export type DoctypeSchema = BaseSchema & {
     options: string;
     label?: string;
     schema?: SchemaTypes[];
-    readOnly?: boolean;
 };
 ```
 
@@ -180,6 +179,16 @@ export type FieldsetSchema = BaseSchema & {
     schema?: (FormSchema | TableSchema)[];
     collapsible?: boolean;
 };
+```
+
+### FormMode
+
+The rendering mode for AForm components
+
+**Definition:**
+
+```typescript
+export type FormMode = 'edit' | 'read' | 'display';
 ```
 
 ### FormSchema
@@ -224,7 +233,6 @@ export type TableDoctypeSchema = BaseSchema & {
     columns?: TableColumn[];
     config?: TableConfig;
     rows?: TableRow[];
-    readOnly?: boolean;
 };
 ```
 

--- a/examples/aform/form.story.vue
+++ b/examples/aform/form.story.vue
@@ -20,7 +20,7 @@
 			</template>
 		</Variant>
 		<Variant title="Form (Read-Only)">
-			<AForm class="aform-main" :schema="basic_form_schema" v-model:data="data" :readOnly="true" />
+			<AForm class="aform-main" :schema="basic_form_schema" v-model:data="data" :mode="'read'" />
 		</Variant>
 		<Variant title="Table">
 			<AForm class="aform-main" :schema="table_schema" v-model:data="data" />

--- a/examples/aform/nested.story.vue
+++ b/examples/aform/nested.story.vue
@@ -285,9 +285,6 @@ const HSTDemo = defineComponent({
 						h('div', { class: 'path-indicator' }, `HST Path: ${this.customerPath}`),
 						h(AForm, {
 							schema: this.resolvedSchema,
-							'onUpdate:schema': (val: any) => {
-								this.resolvedSchema = val
-							},
 							data: this.customerFormData,
 							'onUpdate:data': (val: any) => {
 								this.customerFormData = val
@@ -393,9 +390,6 @@ const AddressListDemo = defineComponent({
 			),
 			h(AForm, {
 				schema: this.resolvedSchema,
-				'onUpdate:schema': (val: any) => {
-					this.resolvedSchema = val
-				},
 				data: this.customerData,
 				'onUpdate:data': (val: any) => {
 					this.customerData = val

--- a/examples/atable/default.story.vue
+++ b/examples/atable/default.story.vue
@@ -128,7 +128,7 @@ const readonly_columns: TableColumn[] = [
 		edit: false,
 		width: '25ch',
 		modalComponent: 'DateInput',
-		modalComponentExtraProps: { readOnly: true },
+		modalComponentExtraProps: { mode: 'read' },
 		format: (value: number) => new Date(value).toLocaleDateString('en-US'),
 	},
 ]

--- a/examples/desktop/components/Home.vue
+++ b/examples/desktop/components/Home.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="home-wrapper">
-		<AForm v-model="schema" />
+		<AForm :schema="schema" v-model:data="tableData" />
 	</div>
 </template>
 
@@ -9,6 +9,8 @@ import { AForm } from '@stonecrop/aform'
 import { ref } from 'vue'
 
 const { doctypes = ['todo', 'issue'] } = defineProps<{ doctypes?: string[] }>()
+
+const tableData = ref<Record<string, any>>({})
 
 // Create schema for displaying doctypes in an ATable
 const schema = ref([

--- a/examples/desktop/index.ts
+++ b/examples/desktop/index.ts
@@ -4,7 +4,6 @@ import { createApp } from 'vue'
 
 import '@stonecrop/desktop/styles'
 import { install as AForm } from '@stonecrop/aform'
-import { install as ATable } from '@stonecrop/atable'
 import { StonecropDesktop } from '@stonecrop/desktop'
 import StonecropPlugin, {
 	DoctypeMeta,
@@ -62,8 +61,8 @@ app.use(StonecropPlugin, {
 })
 
 // 3. Component plugins
+// Note: AForm internally installs ATable, so ATable must not be installed separately
 app.use(AForm)
-app.use(ATable)
 app.use(StonecropDesktop)
 
 // Mount the app - router initialization will happen automatically

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,9 @@
 		"_phase:build": "",
 		"build": "",
 		"story": "histoire dev",
-		"build:stories": "histoire build"
+		"build:stories": "histoire build",
+		"desktop": "vite --config desktop/vite.config.ts desktop",
+		"docbuilder": "vite --config docbuilder/vite.config.ts docbuilder"
 	},
 	"dependencies": {
 		"@stonecrop/aform": "workspace:*",

--- a/graphql_client/eslint.config.js
+++ b/graphql_client/eslint.config.js
@@ -29,7 +29,7 @@ export default defineConfig(
 			},
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['tests/**/*.ts'],
+					allowDefaultProject: ['tests/*.ts'],
 				},
 				tsconfigRootDir: import.meta.dirname,
 				extraFileExtensions: ['.vue'],

--- a/stonecrop/docs/schema/nested-schemas.md
+++ b/stonecrop/docs/schema/nested-schemas.md
@@ -97,7 +97,7 @@ AForm:
 │    <AForm                                                  │
 │      :schema="field.schema"                                │
 │      v-model:data="nestedData[field.fieldname]"            │
-│      :read-only="readOnly || field.readOnly"               │
+│      :mode="field.mode ?? mode"                            │
 │    />                                                      │
 │  </div>                                                    │
 │                                                            │
@@ -365,7 +365,7 @@ AForm detects nested schemas and renders recursively:
     <AForm
       v-model:data="nestedData[field.fieldname]"
       :schema="field.schema"
-      :read-only="readOnly || field.readOnly"
+      :mode="field.mode ?? mode"
     />
   </div>
 

--- a/stonecrop/eslint.config.js
+++ b/stonecrop/eslint.config.js
@@ -34,7 +34,7 @@ export default defineConfig(
 			parser: tseslint.parser,
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['tests/**/*.ts', 'tests/**/*.spec.ts'],
+					allowDefaultProject: ['tests/*.ts', 'tests/actions/*.ts', 'tests/hst/*.ts'],
 				},
 				tsconfigRootDir: import.meta.dirname,
 				extraFileExtensions: ['.vue'],

--- a/stonecrop/src/stores/hst.ts
+++ b/stonecrop/src/stores/hst.ts
@@ -549,6 +549,11 @@ class HSTProxy implements HSTNode {
 				return
 			}
 
+			// Skip triggering when the value did not actually change
+			if (Object.is(beforeValue, afterValue)) {
+				return
+			}
+
 			const pathSegments = fullPath.split('.')
 
 			// Only trigger field actions for actual field changes (at least 3 levels deep: doctype.recordId.fieldname)

--- a/stonecrop/tests/hst/integration.spec.ts
+++ b/stonecrop/tests/hst/integration.spec.ts
@@ -107,7 +107,6 @@ describe('HST Real Component Integration', () => {
 						<AForm
 							:schema="formSchema"
 							v-model:data="formData"
-							@update:schema="handleFormUpdate"
 						/>
 						<div class="debug-info">
 							<div>HST Data: {{ JSON.stringify(hstFormData) }}</div>
@@ -116,38 +115,18 @@ describe('HST Real Component Integration', () => {
 					</div>
 				`,
 				setup() {
-					const { formData, handleHSTChange, provideHSTPath, hstStore } = useStonecrop({
+					const { formData, hstStore } = useStonecrop({
 						doctype,
 						recordId: 'test-task',
 					})
 
-					// Create form schema that uses HST paths
-					const formSchema = ref(
-						doctype.schema?.toArray().map(field => ({
-							...field,
-							value: formData.value[field.fieldname] || getDefaultValue(field.fieldtype),
-						}))
-					)
-
-					const handleFormUpdate = (updatedSchema: SchemaTypes[]) => {
-						// Handle form updates by propagating to HST
-						updatedSchema.forEach(field => {
-							if (field.value !== undefined) {
-								const hstPath = provideHSTPath(field.fieldname)
-								handleHSTChange({
-									path: hstPath,
-									value: field.value,
-									fieldname: field.fieldname,
-								})
-							}
-						})
-					}
+					// Schema is purely structural — no value fields
+					const formSchema = ref(doctype.schema?.toArray().map(field => ({ ...field })))
 
 					return {
 						formSchema,
 						formData,
 						hstFormData: formData,
-						handleFormUpdate,
 						hstStore,
 					}
 				},
@@ -588,30 +567,3 @@ describe('HST Real Component Integration', () => {
 		})
 	})
 })
-
-/**
- * Helper function to get default values for different field types
- */
-function getDefaultValue(fieldtype?: string): any {
-	switch (fieldtype) {
-		case 'Data':
-		case 'Text':
-			return ''
-		case 'Int':
-		case 'Float':
-			return 0
-		case 'Check':
-			return false
-		case 'Date':
-		case 'Datetime':
-			return null
-		case 'Select':
-			return ''
-		case 'JSON':
-			return {}
-		case 'Table':
-			return []
-		default:
-			return null
-	}
-}


### PR DESCRIPTION
This PR separates the immutable schema layer with the mutable data layer in AForm (the design partly caused the infinite loop code seen in #362). The API now changes from:

```vue
<AForm v-model="schema" v-model:data="data" />
```

to

```vue
<AForm :schema="schema" v-model:data="data" />
```

Best way to test the new reactivity in general this would be to run `rushx desktop` inside the `examples` folder.