### PR TITLE
[project] remove auto-mask, fix dropdown mismatch, remove sideEffects

### DIFF
--- a/aform/src/components/form/ADropdown.vue
+++ b/aform/src/components/form/ADropdown.vue
@@ -36,30 +36,33 @@
 
 <script setup lang="ts">
 import { vOnClickOutside } from '@vueuse/components'
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 
 import type { ComponentProps } from '../../types'
 
 const {
 	label,
-	items = [],
+	options = [],
 	isAsync = false,
 	filterFunction = undefined,
 	mode,
 } = defineProps<
 	ComponentProps & {
-		items?: string[]
+		options?: string[]
 		isAsync?: boolean
 		filterFunction?: (search: string) => string[] | Promise<string[]>
 	}
 >()
 const search = defineModel<string>()
 
+// tracks the last explicitly-committed value so outside-click reverts instead of clears
+const committedValue = ref(search.value ?? '')
+
 const dropdown = reactive({
 	activeItemIndex: null as number | null,
 	open: false,
 	loading: false,
-	results: items,
+	results: options,
 })
 
 const onClickOutside = () => closeDropdown()
@@ -84,29 +87,31 @@ const filter = async () => {
 
 const setResult = (result: string) => {
 	search.value = result
+	committedValue.value = result
 	closeDropdown(result)
 }
 
 const openDropdown = () => {
-	dropdown.activeItemIndex = isAsync ? null : search.value ? items?.indexOf(search.value) || null : null
+	const idx = options?.indexOf(search.value ?? '') ?? -1
+	dropdown.activeItemIndex = isAsync ? null : idx >= 0 ? idx : null
 	dropdown.open = true
 	// TODO: this should probably call the async function if it's async
-	dropdown.results = isAsync ? [] : items
+	dropdown.results = isAsync ? [] : options
 }
 
 const closeDropdown = (result?: string) => {
 	dropdown.activeItemIndex = null
 	dropdown.open = false
-	if (!items?.includes(result || search.value || '')) {
-		search.value = ''
+	if (!options?.includes(result || search.value || '')) {
+		search.value = committedValue.value
 	}
 }
 
 const filterResults = () => {
 	if (!search.value) {
-		dropdown.results = items
+		dropdown.results = options
 	} else {
-		dropdown.results = items?.filter(item => item.toLowerCase().includes((search.value ?? '').toLowerCase()))
+		dropdown.results = options?.filter(item => item.toLowerCase().includes((search.value ?? '').toLowerCase()))
 	}
 }
 

--- a/aform/src/directives/mask.ts
+++ b/aform/src/directives/mask.ts
@@ -1,19 +1,5 @@
 import type { DirectiveBinding } from 'vue'
 
-import type { FormSchema } from '../types'
-
-/**
- * Named masks for common input types
- */
-const NAMED_MASKS = {
-	date: '##/##/####',
-	datetime: '####/##/## ##:##',
-	time: '##:##',
-	fulltime: '##:##:##',
-	phone: '(###) ### - ####',
-	card: '#### #### #### ####',
-}
-
 /**
  * Extracts a mask function from a stringified function
  * @param mask - Mask string
@@ -36,23 +22,15 @@ function extractMaskFn(mask: string): ((args: any) => string) | void {
  * @returns Mask string
  */
 function getMask(binding: DirectiveBinding<string>) {
-	let mask = binding.value
+	const mask = binding.value
+	if (!mask) return undefined
 
-	if (mask) {
-		const maskFn = extractMaskFn(mask)
-		if (maskFn) {
-			// TODO: (state) replace with state management;
-			// pass the entire form/table data to the function
-			const locale = binding.instance?.['locale']
-			mask = maskFn(locale)
-		}
-	} else {
-		// TODO: (state) handle using state management
-		const schema = binding.instance?.['schema'] as FormSchema
-		const fieldType: string | undefined = schema?.fieldtype?.toLowerCase()
-		if (fieldType && NAMED_MASKS[fieldType]) {
-			mask = NAMED_MASKS[fieldType]
-		}
+	const maskFn = extractMaskFn(mask)
+	if (maskFn) {
+		// TODO: (state) replace with state management;
+		// pass the entire form/table data to the function
+		const locale = binding.instance?.['locale']
+		return maskFn(locale) as string
 	}
 
 	return mask

--- a/aform/src/types/index.ts
+++ b/aform/src/types/index.ts
@@ -24,7 +24,10 @@ export type ComponentProps = {
 	label?: string
 
 	/**
-	 * The masking string to apply to inputs inside the component
+	 * The mask to apply to inputs inside the component. Accepts either a plain
+	 * mask string (e.g. `"(###) ###-####"`) or a stringified arrow function that
+	 * receives `locale` and returns a mask string
+	 * (e.g. `"(locale) => locale === 'en-US' ? '(###) ###-####' : '####-######'"`).
 	 * @public
 	 */
 	mask?: string
@@ -110,17 +113,6 @@ export type FormSchema = BaseSchema & {
 
 	/**
 	 * The field type for the schema field
-	 *
-	 * @remarks
-	 * This must be a string that represents the field type. A mask string will be automatically
-	 * applied for the following field types:
-	 * - Date ('##/##/####')
-	 * - Datetime ('####/##/## ##:##')
-	 * - Time ('##:##')
-	 * - Fulltime ('##:##:##')
-	 * - Phone ('(###) ### - ####')
-	 * - Card ('#### #### #### ####')
-	 *
 	 * @public
 	 */
 	fieldtype?: string
@@ -144,8 +136,11 @@ export type FormSchema = BaseSchema & {
 	width?: string
 
 	/**
-	 * The mask string for the field
-	 * @beta
+	 * The mask to apply to the field. Accepts either a plain mask string
+	 * (e.g. `"##/##/####"`) or a stringified arrow function that receives `locale`
+	 * and returns a mask string
+	 * (e.g. `"(locale) => locale === 'en-US' ? '(###) ###-####' : '####-######'"`).
+	 * @public
 	 */
 	mask?: string
 }

--- a/aform/tests/dropdown.spec.ts
+++ b/aform/tests/dropdown.spec.ts
@@ -5,14 +5,14 @@ import ADropdown from '../src/components/form/ADropdown.vue'
 
 describe('dropdown input component', () => {
 	const dropdownData = {
-		items: ['Apple', 'Orange', 'Pear', 'Kiwi', 'Grape'],
+		options: ['Apple', 'Orange', 'Pear', 'Kiwi', 'Grape'],
 		value: 'Orange',
 		label: 'Fruit',
 	}
 
 	it('emits update event when dropdown is cleared', async () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: dropdownData.value, label: dropdownData.label, items: dropdownData.items },
+			props: { modelValue: dropdownData.value, label: dropdownData.label, options: dropdownData.options },
 		})
 
 		await wrapper.find('input').setValue('')
@@ -23,7 +23,7 @@ describe('dropdown input component', () => {
 
 	it('emits value update event when dropdown item is selected using mouse', async () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: dropdownData.value, label: dropdownData.label, items: dropdownData.items },
+			props: { modelValue: dropdownData.value, label: dropdownData.label, options: dropdownData.options },
 		})
 
 		const input = wrapper.find('input')
@@ -48,7 +48,7 @@ describe('dropdown input component', () => {
 
 	it('emits value update event when dropdown item is selected using keys', async () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: dropdownData.value, label: dropdownData.label, items: dropdownData.items },
+			props: { modelValue: dropdownData.value, label: dropdownData.label, options: dropdownData.options },
 		})
 
 		const input = wrapper.find('input')
@@ -96,7 +96,12 @@ describe('dropdown input component', () => {
 
 	it('emits filter change event when dropdown item is selected using mouse in sync', async () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: dropdownData.value, label: dropdownData.label, items: dropdownData.items, isAsync: false },
+			props: {
+				modelValue: dropdownData.value,
+				label: dropdownData.label,
+				options: dropdownData.options,
+				isAsync: false,
+			},
 		})
 
 		const input = wrapper.find('input')
@@ -131,7 +136,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: dropdownData.value,
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 				isAsync: true,
 				filterFunction: mockFilterFunction,
 			},
@@ -156,7 +161,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: 'Orange',
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 				isAsync: true,
 			},
 		})
@@ -173,7 +178,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: dropdownData.value,
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 			},
 		})
 
@@ -191,12 +196,37 @@ describe('dropdown input component', () => {
 		expect(updateEvents).toBeTruthy()
 	})
 
+	it('outside-click reverts to last committed value instead of clearing', async () => {
+		const wrapper = mount(ADropdown, {
+			props: {
+				modelValue: 'Orange',
+				label: dropdownData.label,
+				options: dropdownData.options,
+			},
+		})
+
+		const input = wrapper.find('input')
+		await input.trigger('focus')
+		// type something that is not a valid option
+		await input.setValue('Xyz')
+		await wrapper.vm.$nextTick()
+
+		// Escape is wired to onClickOutside → closeDropdown with no result
+		await input.trigger('keydown.esc')
+		await wrapper.vm.$nextTick()
+
+		// should revert to the last committed value ('Orange'), not clear to ''
+		const updateEvents = wrapper.emitted('update:modelValue')
+		const lastEvent = updateEvents![updateEvents!.length - 1]
+		expect(lastEvent).toEqual(['Orange'])
+	})
+
 	it('should handle selectPrevResult when at first item', async () => {
 		const wrapper = mount(ADropdown, {
 			props: {
 				modelValue: dropdownData.value,
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 			},
 		})
 
@@ -225,7 +255,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: '',
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 				isAsync: true,
 				filterFunction: mockFilterFunction,
 			},
@@ -244,7 +274,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: dropdownData.value,
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 			},
 		})
 
@@ -264,7 +294,7 @@ describe('dropdown input component', () => {
 			props: {
 				modelValue: dropdownData.value,
 				label: dropdownData.label,
-				items: dropdownData.items,
+				options: dropdownData.options,
 			},
 		})
 
@@ -281,7 +311,7 @@ describe('dropdown input component', () => {
 
 	it('pressing up with no selection jumps to last item', async () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: '', label: dropdownData.label, items: dropdownData.items },
+			props: { modelValue: '', label: dropdownData.label, options: dropdownData.options },
 		})
 
 		const input = wrapper.find('input')
@@ -304,7 +334,7 @@ describe('dropdown input component', () => {
 
 	it('renders in display mode as text without input', () => {
 		const wrapper = mount(ADropdown, {
-			props: { modelValue: 'Apple', label: dropdownData.label, items: dropdownData.items, mode: 'display' },
+			props: { modelValue: 'Apple', label: dropdownData.label, options: dropdownData.options, mode: 'display' },
 		})
 		expect(wrapper.find('input').exists()).toBe(false)
 		expect(wrapper.find('.aform_display-value').text()).toBe('Apple')

--- a/aform/tests/form.spec.ts
+++ b/aform/tests/form.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 
 import AForm from '../src/components/AForm.vue'
 import ATextInput from '../src/components/form/ATextInput.vue'
-import type { SchemaTypes } from '../src/types'
+import type { SchemaTypes, FormSchema } from '../src/types'
 
 describe('AForm Component', () => {
 	const wrapper = mount(AForm, {
@@ -102,5 +102,70 @@ describe('AForm Component', () => {
 		})
 
 		expect(modeWrapper.vm).toBeTruthy()
+	})
+
+	describe('schema-driven mask', () => {
+		it('passes mask from schema field to ATextInput', async () => {
+			const schema: SchemaTypes[] = [
+				{
+					fieldname: 'phone',
+					fieldtype: 'Data',
+					component: 'ATextInput',
+					label: 'Phone',
+					mask: '(###) ### - ####',
+				} as FormSchema,
+			]
+
+			const wrapper = mount(AForm, {
+				props: { schema, data: {} },
+				components: { ATextInput },
+			})
+
+			await wrapper.vm.$nextTick()
+			const textInput = wrapper.findComponent(ATextInput)
+			expect(textInput.props('mask')).toBe('(###) ### - ####')
+		})
+
+		it('applies mask directive to input when mask is in schema', async () => {
+			const schema: SchemaTypes[] = [
+				{
+					fieldname: 'phone',
+					fieldtype: 'Data',
+					component: 'ATextInput',
+					label: 'Phone',
+					mask: '###-###-####',
+				} as FormSchema,
+			]
+
+			const wrapper = mount(AForm, {
+				props: { schema, data: { phone: '5551234567' } },
+				components: { ATextInput },
+			})
+
+			await wrapper.vm.$nextTick()
+			const input = wrapper.find('input')
+			// mask length is 12, and the value is fully masked so maxlength is set
+			expect(input.attributes('maxlength')).toBe('12')
+		})
+
+		it('does not set maxlength when no mask is in schema', async () => {
+			const schema: SchemaTypes[] = [
+				{
+					fieldname: 'first_name',
+					fieldtype: 'Data',
+					component: 'ATextInput',
+					label: 'First Name',
+				} as FormSchema,
+			]
+
+			const wrapper = mount(AForm, {
+				props: { schema, data: {} },
+				components: { ATextInput },
+			})
+
+			await wrapper.vm.$nextTick()
+			const input = wrapper.find('input')
+			expect(input.attributes('maxlength')).toBeUndefined()
+		})
 	})
 })

--- a/aform/tests/mask.spec.ts
+++ b/aform/tests/mask.spec.ts
@@ -49,8 +49,8 @@ describe('useStringMask', () => {
 
 		it('returns early when no mask is resolved', () => {
 			const el = createMockInput('hello')
-			// binding.value is undefined and no schema with fieldtype
-			useStringMask(el, createBinding(undefined, {}))
+			// binding.value is undefined — no mask, no implicit schema sniffing
+			useStringMask(el, createBinding(undefined))
 
 			// Value unchanged (no mask applied)
 			expect(el.value).toBe('hello')
@@ -61,79 +61,6 @@ describe('useStringMask', () => {
 			useStringMask(el, createBinding('#### #### #### ####'))
 
 			expect(el.value).toBe('4242 4242 4242 4242')
-		})
-	})
-
-	describe('with named masks from schema fieldtype', () => {
-		it('applies mask from schema date fieldtype', () => {
-			const el = createMockInput('01012024')
-			const instance = {
-				schema: { fieldtype: 'Date', fieldname: 'date' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('01/01/2024')
-		})
-
-		it('applies mask from schema time fieldtype', () => {
-			const el = createMockInput('1230')
-			const instance = {
-				schema: { fieldtype: 'Time', fieldname: 'time' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('12:30')
-		})
-
-		it('applies mask from schema fulltime fieldtype', () => {
-			const el = createMockInput('123045')
-			const instance = {
-				schema: { fieldtype: 'Fulltime', fieldname: 'fulltime' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('12:30:45')
-		})
-
-		it('applies mask from schema phone fieldtype', () => {
-			const el = createMockInput('5551234567')
-			const instance = {
-				schema: { fieldtype: 'Phone', fieldname: 'phone' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('(555) 123 - 4567')
-		})
-
-		it('applies mask from schema datetime fieldtype', () => {
-			const el = createMockInput('202401011230')
-			const instance = {
-				schema: { fieldtype: 'Datetime', fieldname: 'datetime' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('2024/01/01 12:30')
-		})
-
-		it('applies card mask from schema', () => {
-			const el = createMockInput('4242424242424242')
-			const instance = {
-				schema: { fieldtype: 'Card', fieldname: 'card' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			expect(el.value).toBe('4242 4242 4242 4242')
-		})
-
-		it('does not apply mask when fieldtype has no named mask', () => {
-			const el = createMockInput('hello')
-			const instance = {
-				schema: { fieldtype: 'Data', fieldname: 'name' },
-			}
-			useStringMask(el, createBinding(undefined, instance))
-
-			// No named mask for 'Data', value unchanged
-			expect(el.value).toBe('hello')
 		})
 	})
 

--- a/code_editor/package.json
+++ b/code_editor/package.json
@@ -27,7 +27,10 @@
 		"dist/*",
 		"src/*"
 	],
-	"sideEffects": false,
+	"sideEffects": [
+		"**/*.vue",
+		"**/*.css"
+	],
 	"scripts": {
 		"_phase:build": "heft build && vite build && rushx docs",
 		"prepublishOnly": "heft build && vite build && rushx docs",

--- a/common/changes/@stonecrop/aform/fix-multiple-stonecrop-issues_2026-03-12-10-31.json
+++ b/common/changes/@stonecrop/aform/fix-multiple-stonecrop-issues_2026-03-12-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "remove auto-masking from components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/code-editor/fix-multiple-stonecrop-issues_2026-03-12-10-36.json
+++ b/common/changes/@stonecrop/code-editor/fix-multiple-stonecrop-issues_2026-03-12-10-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/code-editor",
+      "comment": "remove side effects from code editor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/code-editor"
+}

--- a/common/changes/@stonecrop/graphql-middleware/fix-multiple-stonecrop-issues_2026-03-12-10-31.json
+++ b/common/changes/@stonecrop/graphql-middleware/fix-multiple-stonecrop-issues_2026-03-12-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-middleware",
+      "comment": "remove sideEffects to avoid tree-shaking",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-middleware"
+}

--- a/common/changes/@stonecrop/schema/fix-multiple-stonecrop-issues_2026-03-12-10-45.json
+++ b/common/changes/@stonecrop/schema/fix-multiple-stonecrop-issues_2026-03-12-10-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/schema",
+      "comment": "update masking documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/schema"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -13,7 +13,7 @@
 		"definitionName": "lockStepVersion",
 		"policyName": "stonecrop",
 		"version": "0.10.0",
-		"nextBump": "minor"
+		"nextBump": "patch"
 	}
 	// {
 	//   /**

--- a/examples/aform/dropdown.story.vue
+++ b/examples/aform/dropdown.story.vue
@@ -4,13 +4,13 @@
 			<!-- normal dropdown story -->
 			<ADropdown
 				data-theme="purple"
-				:items="dropdown_data.items"
+				:options="dropdown_data.items"
 				v-model="dropdown_data.value"
 				:label="dropdown_data.label" />
 
 			<!-- dropdown with API request simulation -->
 			<ADropdown
-				:items="async_dropdown_data.items"
+				:options="async_dropdown_data.items"
 				v-model="async_dropdown_data.value"
 				:label="async_dropdown_data.label"
 				:isAsync="true"
@@ -18,7 +18,7 @@
 
 			<!-- dropdown with custom filtering logic -->
 			<ADropdown
-				:items="custom_filter_dropdown_data.items"
+				:options="custom_filter_dropdown_data.items"
 				v-model="custom_filter_dropdown_data.value"
 				:label="custom_filter_dropdown_data.label"
 				:isAsync="false"

--- a/graphql_middleware/package.json
+++ b/graphql_middleware/package.json
@@ -13,7 +13,6 @@
 		"dist"
 	],
 	"description": "GraphQL middleware for PostGraphile and Stonecrop schema",
-	"sideEffects": false,
 	"scripts": {
 		"_phase:build": "heft build && vite build && rushx docs",
 		"prepublishOnly": "heft build && vite build && rushx docs",

--- a/schema/src/converter/scalars.ts
+++ b/schema/src/converter/scalars.ts
@@ -49,7 +49,7 @@ export const WELL_KNOWN_SCALARS: Record<string, FieldTemplate> = {
 	// Date / Time
 	DateTime: { component: 'ADatetimePicker', fieldtype: 'Datetime' },
 	Datetime: { component: 'ADatetimePicker', fieldtype: 'Datetime' },
-	Date: { component: 'ADatePicker', fieldtype: 'Date' },
+	Date: { component: 'ADate', fieldtype: 'Date' },
 	Time: { component: 'ATimeInput', fieldtype: 'Time' },
 	Interval: { component: 'ADurationInput', fieldtype: 'Duration' },
 	Duration: { component: 'ADurationInput', fieldtype: 'Duration' },

--- a/schema/src/field.ts
+++ b/schema/src/field.ts
@@ -109,7 +109,14 @@ export const FieldMeta = z.object({
 	 */
 	options: FieldOptions.optional(),
 
-	/** Input mask pattern (e.g., "##/##/####" for dates) */
+	/**
+	 * Input mask pattern. Accepts either a plain mask string or a stringified
+	 * arrow function that receives `locale` and returns a mask string.
+	 *
+	 * Plain pattern: `"##/##/####"`
+	 *
+	 * Function pattern: `"(locale) => locale === 'en-US' ? '(###) ###-####' : '####-######'"`
+	 */
 	mask: z.string().optional(),
 
 	// === VALIDATION ===

--- a/schema/src/fieldtype.ts
+++ b/schema/src/fieldtype.ts
@@ -68,7 +68,7 @@ export const TYPE_MAP: Record<StonecropFieldType, FieldTemplate> = {
 	Check: { component: 'ACheckbox', fieldtype: 'Check' },
 
 	// Date/Time
-	Date: { component: 'ADatePicker', fieldtype: 'Date' },
+	Date: { component: 'ADate', fieldtype: 'Date' },
 	Time: { component: 'ATimeInput', fieldtype: 'Time' },
 	Datetime: { component: 'ADatetimePicker', fieldtype: 'Datetime' },
 	Duration: { component: 'ADurationInput', fieldtype: 'Duration' },

--- a/schema/tests/converter.spec.ts
+++ b/schema/tests/converter.spec.ts
@@ -118,7 +118,7 @@ describe('WELL_KNOWN_SCALARS', () => {
 		expect(WELL_KNOWN_SCALARS.UUID).toEqual({ component: 'ATextInput', fieldtype: 'Data' })
 		expect(WELL_KNOWN_SCALARS.DateTime).toEqual({ component: 'ADatetimePicker', fieldtype: 'Datetime' })
 		expect(WELL_KNOWN_SCALARS.Datetime).toEqual({ component: 'ADatetimePicker', fieldtype: 'Datetime' })
-		expect(WELL_KNOWN_SCALARS.Date).toEqual({ component: 'ADatePicker', fieldtype: 'Date' })
+		expect(WELL_KNOWN_SCALARS.Date).toEqual({ component: 'ADate', fieldtype: 'Date' })
 		expect(WELL_KNOWN_SCALARS.Time).toEqual({ component: 'ATimeInput', fieldtype: 'Time' })
 		expect(WELL_KNOWN_SCALARS.JSON).toEqual({ component: 'ACodeEditor', fieldtype: 'JSON' })
 		expect(WELL_KNOWN_SCALARS.BigInt).toEqual({ component: 'ANumericInput', fieldtype: 'Int' })


### PR DESCRIPTION
**Problem:** All `createdAt`/`modifiedAt` (`Datetime` fieldtype) and `startDate`/`endDate` (`Date` fieldtype) fields show garbled values when a record is loaded from the database. Examples: ISO string `2026-01-01` renders as `20/26/0101`; `2026-03-12T06:11:17.468315+00:00` renders as `2026/03/12 T0:6:`.

**Cause:** The `v-mask` directive in `ATextInput` reads `schema.fieldtype` and auto-applies named masks (`Date` → `##/##/####`, `Datetime` → `####/##/## ##:##`) to the `<input>` element. The mask is applied reactively on value binding, not just on user keystroke events — so existing ISO strings from the database are treated as raw digit input and transformed character-by-character through the mask pattern.

**Solution:** Auto-masking is removed and masks should be explicitly set either using the `mask` property in a doctype schema's field definition or the `v-mask` directive inside a Vue component