### PR TITLE
[stonecrop] resolve async plugin loading issues

### DIFF
--- a/common/changes/@stonecrop/stonecrop/fix-stonecrop-async-plugin-load_2026-03-18-11-42.json
+++ b/common/changes/@stonecrop/stonecrop/fix-stonecrop-async-plugin-load_2026-03-18-11-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "resolve async plugin loading issues",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/reviews/api/stonecrop.api.md
+++ b/common/reviews/api/stonecrop.api.md
@@ -255,6 +255,9 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;
     };
+    isLoading: Ref<boolean>;
+    error: Ref<Error | null>;
+    resolvedDoctype: Ref<Doctype | undefined>;
 };
 
 // @public
@@ -1058,7 +1061,7 @@ export function useStonecrop(): BaseStonecropReturn | HSTStonecropReturn;
 // @public
 export function useStonecrop(options: {
     registry?: Registry;
-    doctype: Doctype;
+    doctype: Doctype | string;
     recordId?: string;
 }): HSTStonecropReturn;
 

--- a/docs/reference/stonecrop.md
+++ b/docs/reference/stonecrop.md
@@ -255,7 +255,7 @@ Unified Stonecrop composable with HST integration for a specific doctype and rec
 ```typescript
 export declare function useStonecrop(options: {
     registry?: Registry;
-    doctype: Doctype;
+    doctype: Doctype | string;
     recordId?: string;
 }): HSTStonecropReturn;
 ```
@@ -264,7 +264,7 @@ export declare function useStonecrop(options: {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| options | `{ registry?: Registry; doctype: Doctype; recordId?: string; }` | Configuration with doctype and optional recordId |
+| options | `{ registry?: Registry; doctype: Doctype \| string; recordId?: string; }` | Configuration with doctype (string slug or Doctype instance) and optional recordId |
 
 ### useUndoRedoShortcuts
 
@@ -1012,6 +1012,9 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;
     };
+    isLoading: Ref<boolean>;
+    error: Ref<Error | null>;
+    resolvedDoctype: Ref<Doctype | undefined>;
 };
 ```
 

--- a/stonecrop/README.md
+++ b/stonecrop/README.md
@@ -84,10 +84,17 @@ export default {
     // Base mode — operation log only, no HST record loading
     const { stonecrop, operationLog } = useStonecrop()
 
-    // HST mode — pass doctype and optional recordId for full integration
+    // HST mode — pass Doctype instance and optional recordId
     const { stonecrop, formData, provideHSTPath, handleHSTChange } = useStonecrop({
       doctype: myDoctype,
       recordId: 'record-123', // omit or pass undefined for new records
+    })
+
+    // HST mode with lazy-loading — pass string doctype slug
+    // Automatically loads doctype via registry.getMeta if not in registry
+    const { isLoading, error, resolvedDoctype, formData } = useStonecrop({
+      doctype: 'plan',
+      recordId: 'record-123',
     })
 
     // Access HST store
@@ -100,6 +107,28 @@ export default {
   }
 }
 ```
+
+### String Doctype Lazy-Loading
+
+When you pass a string doctype slug instead of a `Doctype` instance, `useStonecrop` will:
+
+1. Check if the doctype is already in the Registry
+2. If not, call `registry.getMeta` to lazy-load it
+3. Return `isLoading`, `error`, and `resolvedDoctype` refs for handling the async state
+
+```typescript
+const { isLoading, error, resolvedDoctype, formData } = useStonecrop({
+  doctype: 'plan',  // string slug - triggers lazy-loading
+  recordId: '123',
+})
+
+// In your template:
+// <div v-if="isLoading">Loading doctype...</div>
+// <div v-else-if="error">Error: {{ error.message }}</div>
+// <AForm v-else :schema="resolvedDoctype.schema" v-model:data="formData" />
+```
+
+This pattern eliminates the timing mismatch when loading doctypes asynchronously in Nuxt plugins.
 
 ## Design
 A Doctype defines schema, workflow, and actions.

--- a/stonecrop/api.md
+++ b/stonecrop/api.md
@@ -250,7 +250,7 @@ Unified Stonecrop composable with HST integration for a specific doctype and rec
 ```typescript
 export declare function useStonecrop(options: {
     registry?: Registry;
-    doctype: Doctype;
+    doctype: Doctype | string;
     recordId?: string;
 }): HSTStonecropReturn;
 ```
@@ -259,7 +259,7 @@ export declare function useStonecrop(options: {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| options | `{ registry?: Registry; doctype: Doctype; recordId?: string; }` | Configuration with doctype and optional recordId |
+| options | `{ registry?: Registry; doctype: Doctype \| string; recordId?: string; }` | Configuration with doctype (string slug or Doctype instance) and optional recordId |
 
 ### useUndoRedoShortcuts
 
@@ -1007,6 +1007,9 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;
     };
+    isLoading: Ref<boolean>;
+    error: Ref<Error | null>;
+    resolvedDoctype: Ref<Doctype | undefined>;
 };
 ```
 

--- a/stonecrop/src/composables/stonecrop.ts
+++ b/stonecrop/src/composables/stonecrop.ts
@@ -74,6 +74,9 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
 		provideHSTPath: (fieldname: string) => string
 		handleHSTChange: (changeData: HSTChangeData) => void
 	}
+	isLoading: Ref<boolean>
+	error: Ref<Error | null>
+	resolvedDoctype: Ref<Doctype | undefined>
 }
 
 /**
@@ -98,17 +101,21 @@ export function useStonecrop(): BaseStonecropReturn | HSTStonecropReturn
 /**
  * Unified Stonecrop composable with HST integration for a specific doctype and record
  *
- * @param options - Configuration with doctype and optional recordId
+ * @param options - Configuration with doctype (string slug or Doctype instance) and optional recordId
  * @returns Stonecrop instance with full HST integration utilities
  * @public
  */
-export function useStonecrop(options: { registry?: Registry; doctype: Doctype; recordId?: string }): HSTStonecropReturn
+export function useStonecrop(options: {
+	registry?: Registry
+	doctype: Doctype | string
+	recordId?: string
+}): HSTStonecropReturn
 /**
  * @public
  */
 export function useStonecrop(options?: {
 	registry?: Registry
-	doctype?: Doctype
+	doctype?: Doctype | string
 	recordId?: string
 }): BaseStonecropReturn | HSTStonecropReturn {
 	if (!options) options = {}
@@ -126,14 +133,14 @@ export function useStonecrop(options?: {
 	// Resolved schema with nested Doctype fields expanded
 	const resolvedSchema = ref<SchemaTypes[]>([])
 
-	// Auto-resolve schema when doctype is available
-	if (options.doctype && registry) {
-		const schemaArray = options.doctype.schema
-			? Array.isArray(options.doctype.schema)
-				? options.doctype.schema
-				: Array.from(options.doctype.schema)
-			: []
-		resolvedSchema.value = registry.resolveSchema(schemaArray as SchemaTypes[])
+	// Loading state for lazy-loaded doctypes
+	const isLoading = ref(false)
+	const error = ref<Error | null>(null)
+	const resolvedDoctype = ref<Doctype | undefined>()
+
+	// If doctype is a Doctype instance (not string), set resolved immediately
+	if (options?.doctype && typeof options.doctype !== 'string') {
+		resolvedDoctype.value = options.doctype
 	}
 
 	// Operation log state and methods - will be populated after stonecrop instance is created
@@ -280,7 +287,7 @@ export function useStonecrop(options?: {
 								? doctype.schema
 								: Array.from(doctype.schema)
 							: []
-						resolvedSchema.value = registry.resolveSchema(schemaArray as SchemaTypes[])
+						resolvedSchema.value = registry.resolveSchema(schemaArray)
 					}
 
 					if (recordId && recordId !== 'new') {
@@ -314,8 +321,61 @@ export function useStonecrop(options?: {
 		// Handle HST integration if doctype is provided explicitly
 		if (options.doctype) {
 			hstStore.value = stonecrop.value.getStore()
-			const doctype = options.doctype
 			const recordId = options.recordId
+
+			// Resolve doctype - handle string (lazy-load) or Doctype instance
+			let doctype: Doctype | undefined
+
+			if (typeof options.doctype === 'string') {
+				// String doctype - check registry first, then lazy-load
+				const doctypeSlug = options.doctype
+				isLoading.value = true
+				error.value = null
+
+				try {
+					// Check if already in registry
+					doctype = registry.getDoctype(doctypeSlug)
+
+					if (!doctype && registry.getMeta) {
+						// Lazy-load via getMeta
+						const routeContext: RouteContext = {
+							path: `/${doctypeSlug}`,
+							segments: [doctypeSlug],
+						}
+						doctype = await registry.getMeta(routeContext)
+						if (doctype) {
+							registry.addDoctype(doctype)
+						}
+					}
+
+					if (!doctype) {
+						error.value = new Error(`Doctype '${doctypeSlug}' not found in registry and getMeta returned no result`)
+					}
+				} catch (e) {
+					error.value = e instanceof Error ? e : new Error(String(e))
+				} finally {
+					isLoading.value = false
+				}
+			} else {
+				// Doctype instance provided directly
+				doctype = options.doctype
+			}
+
+			// Set resolved doctype for consumers
+			resolvedDoctype.value = doctype
+
+			if (!doctype) {
+				// Error already set above, just return
+				return
+			}
+
+			// Resolve schema for the doctype
+			const schemaArray = doctype.schema
+				? Array.isArray(doctype.schema)
+					? doctype.schema
+					: Array.from(doctype.schema)
+				: []
+			resolvedSchema.value = registry.resolveSchema(schemaArray)
 
 			if (recordId && recordId !== 'new') {
 				const existingRecord = stonecrop.value.getRecordById(doctype, recordId)
@@ -344,7 +404,7 @@ export function useStonecrop(options?: {
 
 	// HST integration functions - always created but only populated when HST is available
 	const provideHSTPath = (fieldname: string, customRecordId?: string): string => {
-		const doctype = options.doctype || routerDoctype.value
+		const doctype = resolvedDoctype.value || routerDoctype.value
 		if (!doctype) return ''
 
 		const actualRecordId = customRecordId || options.recordId || routerRecordId.value || 'new'
@@ -352,7 +412,7 @@ export function useStonecrop(options?: {
 	}
 
 	const handleHSTChange = (changeData: HSTChangeData): void => {
-		const doctype = options.doctype || routerDoctype.value
+		const doctype = resolvedDoctype.value || routerDoctype.value
 		if (!hstStore.value || !stonecrop.value || !doctype) {
 			return
 		}
@@ -458,9 +518,11 @@ export function useStonecrop(options?: {
 		const payload: Record<string, any> = { ...recordData }
 
 		// Use resolveSchema to get the full resolved tree, then walk Doctype fields
-		const schemaArray = (
-			doctype.schema ? (Array.isArray(doctype.schema) ? doctype.schema : Array.from(doctype.schema)) : []
-		) as SchemaTypes[]
+		const schemaArray = doctype.schema
+			? Array.isArray(doctype.schema)
+				? doctype.schema
+				: Array.from(doctype.schema)
+			: []
 		const resolved = registry ? registry.resolveSchema(schemaArray) : schemaArray
 		const doctypeFields = resolved.filter(
 			field => 'fieldtype' in field && field.fieldtype === 'Doctype' && 'schema' in field && Array.isArray(field.schema)
@@ -539,6 +601,9 @@ export function useStonecrop(options?: {
 			loadNestedData,
 			saveRecursive,
 			createNestedContext,
+			isLoading,
+			error,
+			resolvedDoctype,
 		} as HSTStonecropReturn
 	} else if (!options.doctype && registry?.router) {
 		// Router-based - return HST (will be populated after mount)
@@ -553,6 +618,9 @@ export function useStonecrop(options?: {
 			loadNestedData,
 			saveRecursive,
 			createNestedContext,
+			isLoading,
+			error,
+			resolvedDoctype,
 		} as HSTStonecropReturn
 	}
 

--- a/stonecrop/tests/composable.spec.ts
+++ b/stonecrop/tests/composable.spec.ts
@@ -548,3 +548,269 @@ describe('useStonecrop router-based HST integration', () => {
 		}
 	})
 })
+
+describe('useStonecrop with string doctype lazy-loading', () => {
+	let mockRouter: any
+	let registry: Registry
+	let stonecrop: Stonecrop
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+
+		// Reset static instances
+		Registry._root = undefined as any
+		;(HST as any).instance = undefined
+
+		mockRouter = createRouter({
+			history: createMemoryHistory(),
+			routes: [
+				{ path: '/records/:records', name: 'list', component: {} },
+				{ path: '/records/:records/:record', name: 'form', component: {} },
+			],
+		})
+
+		registry = new Registry(mockRouter)
+		stonecrop = new Stonecrop(registry)
+
+		vi.clearAllMocks()
+	})
+
+	it('accepts string doctype and lazy-loads via getMeta', async () => {
+		const mockDoctype = createMockDoctype('Task')
+		const mockGetMeta = vi.fn().mockResolvedValue(mockDoctype)
+		registry.getMeta = mockGetMeta
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ doctype: 'task', recordId: '123' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		const vm = wrapper.vm as any
+
+		// getMeta should have been called
+		expect(mockGetMeta).toHaveBeenCalledWith({
+			path: '/task',
+			segments: ['task'],
+		})
+
+		// resolvedDoctype should be set
+		expect(vm.resolvedDoctype).toBeDefined()
+		expect(vm.resolvedDoctype?.name).toBe('Task')
+
+		// isLoading should be false after load
+		expect(vm.isLoading).toBe(false)
+
+		// error should be null
+		expect(vm.error).toBeNull()
+	})
+
+	it('returns doctype from registry if already loaded', async () => {
+		const mockDoctype = createMockDoctype('Task')
+		registry.addDoctype(mockDoctype)
+
+		const mockGetMeta = vi.fn()
+		registry.getMeta = mockGetMeta
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ doctype: 'task', recordId: '123' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		const vm = wrapper.vm as any
+
+		// getMeta should NOT have been called since doctype was in registry
+		expect(mockGetMeta).not.toHaveBeenCalled()
+
+		// resolvedDoctype should be set from registry
+		expect(vm.resolvedDoctype).toBeDefined()
+		expect(vm.resolvedDoctype?.name).toBe('Task')
+	})
+
+	it('sets error when doctype not found and no getMeta', async () => {
+		// No getMeta configured, doctype not in registry
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ doctype: 'nonexistent', recordId: '123' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		const vm = wrapper.vm as any
+
+		// isLoading should be false
+		expect(vm.isLoading).toBe(false)
+
+		// error should be set
+		expect(vm.error).toBeDefined()
+		expect(vm.error?.message).toContain('not found in registry')
+
+		// resolvedDoctype should be undefined
+		expect(vm.resolvedDoctype).toBeUndefined()
+	})
+
+	it('sets error when getMeta returns null', async () => {
+		const mockGetMeta = vi.fn().mockResolvedValue(null)
+		registry.getMeta = mockGetMeta
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ doctype: 'nonexistent', recordId: '123' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		const vm = wrapper.vm as any
+
+		expect(vm.isLoading).toBe(false)
+		expect(vm.error).toBeDefined()
+		expect(vm.error?.message).toContain('getMeta returned no result')
+	})
+
+	it('sets error when getMeta throws', async () => {
+		const mockGetMeta = vi.fn().mockRejectedValue(new Error('Network error'))
+		registry.getMeta = mockGetMeta
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ doctype: 'task', recordId: '123' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		const vm = wrapper.vm as any
+
+		expect(vm.isLoading).toBe(false)
+		expect(vm.error).toBeDefined()
+		expect(vm.error?.message).toBe('Network error')
+	})
+
+	it('sets resolvedDoctype immediately for Doctype instance', async () => {
+		const mockDoctype = createMockDoctype('Task')
+
+		const TestComponent = defineComponent({
+			setup() {
+				const result = useStonecrop({ doctype: mockDoctype, recordId: '123' })
+				// Check resolvedDoctype immediately (before onMounted)
+				return {
+					...result,
+					immediateResolvedDoctype: result.resolvedDoctype.value,
+				}
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		const vm = wrapper.vm as any
+
+		// resolvedDoctype should be set immediately for Doctype instance
+		expect(vm.immediateResolvedDoctype).toBeDefined()
+		expect(vm.immediateResolvedDoctype?.name).toBe('Task')
+	})
+
+	it('provides HST path with string doctype after lazy load', async () => {
+		const mockDoctype = createMockDoctype('Task')
+		const mockGetMeta = vi.fn().mockResolvedValue(mockDoctype)
+		registry.getMeta = mockGetMeta
+
+		const TestComponent = defineComponent({
+			setup() {
+				const result = useStonecrop({ doctype: 'task', recordId: 'test-123' })
+				return result
+			},
+			template: '<div>{{ hstPath }}</div>',
+			computed: {
+				hstPath() {
+					return (this as any).provideHSTPath('title')
+				},
+			},
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: {
+				provide: {
+					$registry: registry,
+					$stonecrop: stonecrop,
+				},
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 10))
+
+		// After lazy load, HST path should work
+		expect(wrapper.vm.hstPath).toBe('task.test-123.title')
+	})
+})


### PR DESCRIPTION
Depends on #369 

---

**Observed**: When loading doctypes into the Registry asynchronously in a Nuxt plugin, components that call `useStonecrop({ doctype, recordId })` at initialization time fail because the doctype hasn't been loaded yet:

```
error: "Doctype not loaded in registry"
```

The sequence of events:
1. Nuxt plugin runs asynchronously, calls `loadDoctypesIntoRegistry()` which fetches metadata from GraphQL
2. Component initializes and calls `useStonecrop({ doctype, recordId })` synchronously
3. `useStonecrop` looks up the doctype in Registry via `registry.getDoctype(slug)`
4. The async fetch hasn't completed, so the doctype isn't in the Registry yet

**Workaround applied in fab**: `DoctypeDetail.vue` uses `useStonecrop()` with no arguments (base mode) to get the `stonecrop` instance and `operationLog` without triggering automatic record fetch. Data loading is done manually via `fetchDoctypeRecord()`. After successful fetch, the record is written to HST via `stonecrop.addRecord()` if the doctype is available in the registry.

This workaround:
- Always works regardless of Registry population state
- Uses StonecropClient directly for fetching
- Optionally syncs to HST when available
- Does NOT provide HST-backed `formData` or field triggers

**Root cause**: `useStonecrop({ doctype, recordId })` requires the doctype to be a `DoctypeMeta` class instance already loaded in the Registry. There's no lazy-loading or fallback mechanism.

**Solution implemented**: Accept string doctype slug and lazy-load via `getMeta`:

1. **Accept string doctype parameter**:
   - `useStonecrop({ doctype: 'plan', recordId })` now accepts a string slug in addition to `Doctype` instance
   - If string provided, checks Registry first for existing doctype
   - If not in Registry and `getMeta` is configured, lazily loads metadata via `getMeta({ path, segments })`

2. **Add loading state**:
   - Returns `isLoading` ref (true during lazy load)
   - Returns `error` ref (set if lazy load fails)
   - Returns `resolvedDoctype` ref (the resolved `Doctype` after loading)
   - For `Doctype` instance input, `resolvedDoctype` is set immediately (before `onMounted`)

3. **Desktop.vue integration**:
   - Desktop.vue uses router-based loading, so it doesn't need the string doctype pattern
   - The loading/error states are available if Desktop.vue adopts string doctype in the future

**Usage example**:
```ts
// String doctype with lazy loading
const { isLoading, error, resolvedDoctype, formData } = useStonecrop({
  doctype: 'plan',
  recordId: '123'
})

// Doctype instance (no loading needed)
const doctype = registry.getDoctype('plan')
const { formData, resolvedDoctype } = useStonecrop({ doctype, recordId: '123' })
```

**Rationale**:
- Reduces friction for apps - one-liner instead of manual fetching workaround
- Only requires `getMeta` to be configured (already documented pattern for router-based loading)
- Registry acts as cache - multiple components for same doctype only load once
- Apps can still pre-load doctypes in plugins if desired (optional optimization)