### PR TITLE
[stonecrop] allow workflow objects to be passed to doctype cast

### DIFF
--- a/common/changes/@stonecrop/nuxt/fix-stonecrop-workflow-cast_2026-03-19-10-10.json
+++ b/common/changes/@stonecrop/nuxt/fix-stonecrop-workflow-cast_2026-03-19-10-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/nuxt",
+      "comment": "add name to runtime plugin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/nuxt"
+}

--- a/common/changes/@stonecrop/stonecrop/fix-stonecrop-workflow-cast_2026-03-19-10-10.json
+++ b/common/changes/@stonecrop/stonecrop/fix-stonecrop-workflow-cast_2026-03-19-10-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "allow workflow objects to be passed to doctype cast",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/reviews/api/stonecrop.api.md
+++ b/common/reviews/api/stonecrop.api.md
@@ -17,6 +17,7 @@ import { SchemaTypes } from '@stonecrop/aform';
 import { Store } from 'pinia';
 import { StoreDefinition } from 'pinia';
 import type { UnknownMachineConfig } from 'xstate';
+import type { WorkflowMeta } from '@stonecrop/schema';
 
 // @public
 export interface ActionExecutionResult {
@@ -75,6 +76,14 @@ export class Doctype {
     readonly component?: Component;
     readonly doctype: string;
     static fromObject(config: DoctypeConfig): Doctype;
+    getActionMeta(actionName: string): {
+        label: string;
+        handler: string;
+        requiredFields?: string[];
+        allowedStates?: string[];
+        confirm?: boolean;
+        args?: Record<string, unknown>;
+    } | undefined;
     getActionsObject(): Record<string, string[]>;
     getAvailableTransitions(currentState: string): Array<{
         name: string;
@@ -93,7 +102,7 @@ export type DoctypeConfig = {
     slug?: string;
     tableName?: string;
     fields?: SchemaTypes[];
-    workflow?: UnknownMachineConfig;
+    workflow?: UnknownMachineConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
     inherits?: string;
     listDoctype?: string;
@@ -263,7 +272,7 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
 // @public
 export type ImmutableDoctype = {
     readonly schema?: List<SchemaTypes>;
-    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     readonly actions?: Map_2<string, string[]>;
 };
 
@@ -284,7 +293,7 @@ export function markOperationIrreversible(operationId: string | undefined, reaso
 export type MutableDoctype = {
     doctype?: string;
     schema?: SchemaTypes[];
-    workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
 };
 

--- a/docs/reference/stonecrop.md
+++ b/docs/reference/stonecrop.md
@@ -908,7 +908,7 @@ export type DoctypeConfig = {
     slug?: string;
     tableName?: string;
     fields?: SchemaTypes[];
-    workflow?: UnknownMachineConfig;
+    workflow?: UnknownMachineConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
     inherits?: string;
     listDoctype?: string;
@@ -1027,7 +1027,7 @@ Immutable Doctype type for Stonecrop instances
 ```typescript
 export type ImmutableDoctype = {
     readonly schema?: List<SchemaTypes>;
-    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     readonly actions?: Map<string, string[]>;
 };
 ```
@@ -1059,7 +1059,7 @@ Mutable Doctype type for Stonecrop instances
 export type MutableDoctype = {
     doctype?: string;
     schema?: SchemaTypes[];
-    workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
 };
 ```
@@ -1194,6 +1194,27 @@ fromObject(config: DoctypeConfig): Doctype
 |-----------|------|-------------|
 | config | `DoctypeConfig` | Plain object with doctype configuration (typically from API response) |
 
+#### getActionMeta
+
+Returns metadata for a specific action, if available. Only works with WorkflowMeta format; returns undefined for XState format.
+
+```typescript
+getActionMeta(actionName: string): {
+        label: string;
+        handler: string;
+        requiredFields?: string[];
+        allowedStates?: string[];
+        confirm?: boolean;
+        args?: Record<string, unknown>;
+    } | undefined
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| actionName | `string` | The action name to get metadata for |
+
 #### getActionsObject
 
 Returns the actions as a plain object for use with components that expect plain JavaScript objects.
@@ -1204,7 +1225,7 @@ getActionsObject(): Record<string, string[]>
 
 #### getAvailableTransitions
 
-Returns the transitions available from a given workflow state, derived from the doctype's XState workflow configuration.
+Returns the transitions available from a given workflow state, derived from the doctype's workflow configuration. Supports both XState format and WorkflowMeta format.
 
 ```typescript
 getAvailableTransitions(currentState: string): Array<{

--- a/nuxt/src/runtime/plugin.ts
+++ b/nuxt/src/runtime/plugin.ts
@@ -2,20 +2,24 @@ import { install as AForm } from '@stonecrop/aform'
 import { install as NodeEditor } from '@stonecrop/node-editor'
 import StonecropPlugin from '@stonecrop/stonecrop'
 import { createPinia } from 'pinia'
+
 import { defineNuxtPlugin, useRouter } from 'nuxt/app'
 
-export default defineNuxtPlugin(nuxt => {
-	const router = useRouter()
+export default defineNuxtPlugin({
+	name: 'stonecrop',
+	setup(nuxt) {
+		const router = useRouter()
 
-	const app = nuxt.vueApp
+		const app = nuxt.vueApp
 
-	// Only create Pinia if not already installed (e.g., by pinia, nuxt)
-	if (!app.config.globalProperties.$pinia) {
-		const pinia = createPinia()
-		app.use(pinia)
-	}
+		// Only create Pinia if not already installed (e.g., by pinia, nuxt)
+		if (!app.config.globalProperties.$pinia) {
+			const pinia = createPinia()
+			app.use(pinia)
+		}
 
-	app.use(AForm)
-	app.use(NodeEditor)
-	app.use(StonecropPlugin, { router })
+		app.use(AForm)
+		app.use(NodeEditor)
+		app.use(StonecropPlugin, { router })
+	},
 })

--- a/stonecrop/api.md
+++ b/stonecrop/api.md
@@ -903,7 +903,7 @@ export type DoctypeConfig = {
     slug?: string;
     tableName?: string;
     fields?: SchemaTypes[];
-    workflow?: UnknownMachineConfig;
+    workflow?: UnknownMachineConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
     inherits?: string;
     listDoctype?: string;
@@ -1022,7 +1022,7 @@ Immutable Doctype type for Stonecrop instances
 ```typescript
 export type ImmutableDoctype = {
     readonly schema?: List<SchemaTypes>;
-    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     readonly actions?: Map<string, string[]>;
 };
 ```
@@ -1054,7 +1054,7 @@ Mutable Doctype type for Stonecrop instances
 export type MutableDoctype = {
     doctype?: string;
     schema?: SchemaTypes[];
-    workflow?: UnknownMachineConfig | AnyStateNodeConfig;
+    workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta;
     actions?: Record<string, string[]>;
 };
 ```
@@ -1189,6 +1189,27 @@ fromObject(config: DoctypeConfig): Doctype
 |-----------|------|-------------|
 | config | `DoctypeConfig` | Plain object with doctype configuration (typically from API response) |
 
+#### getActionMeta
+
+Returns metadata for a specific action, if available. Only works with WorkflowMeta format; returns undefined for XState format.
+
+```typescript
+getActionMeta(actionName: string): {
+        label: string;
+        handler: string;
+        requiredFields?: string[];
+        allowedStates?: string[];
+        confirm?: boolean;
+        args?: Record<string, unknown>;
+    } | undefined
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| actionName | `string` | The action name to get metadata for |
+
 #### getActionsObject
 
 Returns the actions as a plain object for use with components that expect plain JavaScript objects.
@@ -1199,7 +1220,7 @@ getActionsObject(): Record<string, string[]>
 
 #### getAvailableTransitions
 
-Returns the transitions available from a given workflow state, derived from the doctype's XState workflow configuration.
+Returns the transitions available from a given workflow state, derived from the doctype's workflow configuration. Supports both XState format and WorkflowMeta format.
 
 ```typescript
 getAvailableTransitions(currentState: string): Array<{

--- a/stonecrop/src/doctype.ts
+++ b/stonecrop/src/doctype.ts
@@ -1,7 +1,7 @@
+import type { SchemaTypes } from '@stonecrop/aform'
+import type { WorkflowMeta } from '@stonecrop/schema'
 import { List, Map } from 'immutable'
 import { Component } from 'vue'
-
-import type { SchemaTypes } from '@stonecrop/aform'
 import type { UnknownMachineConfig } from 'xstate'
 
 import type { ImmutableDoctype } from './types'
@@ -20,8 +20,8 @@ export type DoctypeConfig = {
 	tableName?: string
 	/** Field definitions */
 	fields?: SchemaTypes[]
-	/** Workflow configuration */
-	workflow?: UnknownMachineConfig
+	/** Workflow configuration (XState format or simple WorkflowMeta) */
+	workflow?: UnknownMachineConfig | WorkflowMeta
 	/** Actions and their field triggers */
 	actions?: Record<string, string[]>
 	/** Parent doctype for inheritance */
@@ -183,7 +183,7 @@ export default class Doctype {
 
 	/**
 	 * Returns the transitions available from a given workflow state, derived from the
-	 * doctype's XState workflow configuration.
+	 * doctype's workflow configuration. Supports both XState format and WorkflowMeta format.
 	 *
 	 * @param currentState - The state name to read transitions from
 	 * @returns Array of transition descriptors with `name` and `targetState`
@@ -197,7 +197,34 @@ export default class Doctype {
 	 * @public
 	 */
 	getAvailableTransitions(currentState: string): Array<{ name: string; targetState: string }> {
-		const states = this.workflow?.states
+		const workflow = this.workflow
+		if (!workflow) return []
+
+		// Check if this is WorkflowMeta format (states is an array) or XState format (states is an object)
+		if (Array.isArray(workflow.states)) {
+			// WorkflowMeta format: validate state exists and filter actions by allowedStates
+			const states = workflow.states
+			if (!states.includes(currentState)) return []
+
+			const actions = (workflow as WorkflowMeta).actions
+			if (!actions) return []
+
+			return Object.entries(actions)
+				.filter(([, actionDef]) => {
+					const allowedStates = actionDef.allowedStates
+					// If no allowedStates specified, action is available in all valid states
+					if (!allowedStates || allowedStates.length === 0) return true
+					return allowedStates.includes(currentState)
+				})
+				.map(([name]) => ({
+					name,
+					// WorkflowMeta doesn't define target states - transitions are handled server-side
+					targetState: currentState,
+				}))
+		}
+
+		// XState format: use the on property of the state
+		const states = workflow.states
 		if (!states) return []
 		const stateConfig = states[currentState]
 		if (!stateConfig?.on) return []
@@ -205,6 +232,40 @@ export default class Doctype {
 			name,
 			targetState: typeof target === 'string' ? target : 'unknown',
 		}))
+	}
+
+	/**
+	 * Returns metadata for a specific action, if available.
+	 * Only works with WorkflowMeta format; returns undefined for XState format.
+	 *
+	 * @param actionName - The action name to get metadata for
+	 * @returns Action metadata or undefined
+	 *
+	 * @example
+	 * ```ts
+	 * const actionMeta = doctype.getActionMeta('submit')
+	 * // { label: 'Submit', handler: 'plan:submit', allowedStates: ['draft'] }
+	 * ```
+	 *
+	 * @public
+	 */
+	getActionMeta(
+		actionName: string
+	):
+		| {
+				label: string
+				handler: string
+				requiredFields?: string[]
+				allowedStates?: string[]
+				confirm?: boolean
+				args?: Record<string, unknown>
+		  }
+		| undefined {
+		const workflow = this.workflow
+		if (!workflow || !Array.isArray(workflow.states)) return undefined
+
+		const actions = (workflow as WorkflowMeta).actions
+		return actions?.[actionName]
 	}
 
 	/**

--- a/stonecrop/src/stonecrop.ts
+++ b/stonecrop/src/stonecrop.ts
@@ -1,4 +1,4 @@
-import type { DataClient } from '@stonecrop/schema'
+import type { DataClient, WorkflowMeta } from '@stonecrop/schema'
 import { reactive } from 'vue'
 
 import Doctype from './doctype'
@@ -400,10 +400,20 @@ export class Stonecrop {
 		const record = this.getRecordById(slug, recordId)
 		const status = record?.get('status') as string | undefined
 
-		const initialState =
-			typeof meta.workflow.initial === 'string'
-				? meta.workflow.initial
-				: Object.keys(meta.workflow.states ?? {})[0] ?? ''
+		// Handle both XState format and WorkflowMeta format
+		const workflow = meta.workflow
+		let initialState: string
+
+		if (Array.isArray(workflow.states)) {
+			// WorkflowMeta format: states is a string array
+			initialState = workflow.states[0] ?? ''
+		} else {
+			// XState format: states is an object, use initial or first key
+			initialState =
+				typeof (workflow as { initial?: unknown }).initial === 'string'
+					? (workflow as { initial: string }).initial
+					: Object.keys(workflow.states ?? {})[0] ?? ''
+		}
 
 		return status || initialState
 	}

--- a/stonecrop/src/types/index.ts
+++ b/stonecrop/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { DataClient } from '@stonecrop/schema'
+import type { DataClient, WorkflowMeta } from '@stonecrop/schema'
 import type { SchemaTypes } from '@stonecrop/aform'
 import { List, Map } from 'immutable'
 import type { Component } from 'vue'
@@ -16,7 +16,7 @@ import type { RouteContext } from './registry'
  */
 export type ImmutableDoctype = {
 	readonly schema?: List<SchemaTypes> // TODO: allow schema to be a function
-	readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig
+	readonly workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta
 	readonly actions?: Map<string, string[]>
 }
 
@@ -27,7 +27,7 @@ export type ImmutableDoctype = {
 export type MutableDoctype = {
 	doctype?: string
 	schema?: SchemaTypes[] // TODO: allow schema to be a function
-	workflow?: UnknownMachineConfig | AnyStateNodeConfig
+	workflow?: UnknownMachineConfig | AnyStateNodeConfig | WorkflowMeta
 	actions?: Record<string, string[]>
 }
 

--- a/stonecrop/tests/doctype.spec.ts
+++ b/stonecrop/tests/doctype.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { List, Map } from 'immutable'
 import type { UnknownMachineConfig } from 'xstate'
+import type { WorkflowMeta } from '@stonecrop/schema'
 
 import Doctype from '../src/doctype'
 import type { SchemaTypes } from '@stonecrop/aform'
@@ -190,6 +191,79 @@ describe('Doctype class', () => {
 			expect(transitions[0].name).toBe('CLOSE')
 			expect(transitions[0].targetState).toBe('closed')
 		})
+
+		describe('WorkflowMeta format', () => {
+			const workflowMeta: WorkflowMeta = {
+				states: ['planning', 'review', 'approved', 'applied'],
+				actions: {
+					save: { label: 'Save', handler: 'plan:save', allowedStates: ['planning'] },
+					submit: { label: 'Submit', handler: 'plan:submit', allowedStates: ['planning'] },
+					approve: { label: 'Approve', handler: 'plan:approve', allowedStates: ['review'], confirm: true },
+					reject: { label: 'Reject', handler: 'plan:reject', allowedStates: ['review'] },
+					apply: { label: 'Apply', handler: 'plan:apply', allowedStates: ['planning', 'approved'] },
+					global: { label: 'Global', handler: 'plan:global' },
+				},
+			}
+
+			it('filters actions by allowedStates', () => {
+				const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+				const planningTransitions = doctype.getAvailableTransitions('planning')
+				expect(planningTransitions).toHaveLength(4)
+				const planningNames = planningTransitions.map(t => t.name).sort()
+				expect(planningNames).toEqual(['apply', 'global', 'save', 'submit'])
+
+				const reviewTransitions = doctype.getAvailableTransitions('review')
+				expect(reviewTransitions).toHaveLength(3)
+				const reviewNames = reviewTransitions.map(t => t.name).sort()
+				expect(reviewNames).toEqual(['approve', 'global', 'reject'])
+
+				const approvedTransitions = doctype.getAvailableTransitions('approved')
+				expect(approvedTransitions).toHaveLength(2)
+				const approvedNames = approvedTransitions.map(t => t.name).sort()
+				expect(approvedNames).toEqual(['apply', 'global'])
+			})
+
+			it('includes actions without allowedStates in all states', () => {
+				const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+				const planningTransitions = doctype.getAvailableTransitions('planning')
+				expect(planningTransitions.some(t => t.name === 'global')).toBe(true)
+
+				const reviewTransitions = doctype.getAvailableTransitions('review')
+				expect(reviewTransitions.some(t => t.name === 'global')).toBe(true)
+			})
+
+			it('returns current state as targetState (server-side transitions)', () => {
+				const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+				const transitions = doctype.getAvailableTransitions('planning')
+				transitions.forEach(t => {
+					expect(t.targetState).toBe('planning')
+				})
+			})
+
+			it('returns empty array for state not in states list', () => {
+				const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+				const transitions = doctype.getAvailableTransitions('unknown')
+				expect(transitions).toEqual([])
+			})
+
+			it('handles empty actions', () => {
+				const noActions: WorkflowMeta = { states: ['draft', 'submitted'] }
+				const doctype = new Doctype('Task', mockSchema, noActions, mockActions)
+
+				expect(doctype.getAvailableTransitions('draft')).toEqual([])
+			})
+
+			it('handles empty states', () => {
+				const noStates: WorkflowMeta = { actions: { save: { label: 'Save', handler: 'save' } } }
+				const doctype = new Doctype('Task', mockSchema, noStates, mockActions)
+
+				expect(doctype.getAvailableTransitions('draft')).toEqual([])
+			})
+		})
 	})
 
 	describe('fromObject', () => {
@@ -296,6 +370,53 @@ describe('Doctype class', () => {
 			// String-style target: 'SUBMIT: 'pending'' extracts targetState correctly
 			expect(doctype.getAvailableTransitions('draft')).toEqual([{ name: 'SUBMIT', targetState: 'pending' }])
 		})
+
+		it('accepts WorkflowMeta format for workflow', () => {
+			const obj = {
+				name: 'Plan',
+				workflow: {
+					states: ['draft', 'submitted', 'approved'],
+					actions: {
+						submit: { label: 'Submit', handler: 'plan:submit', allowedStates: ['draft'] },
+						approve: { label: 'Approve', handler: 'plan:approve', allowedStates: ['submitted'] },
+					},
+				} as WorkflowMeta,
+			}
+
+			const doctype = Doctype.fromObject(obj)
+
+			expect(doctype.workflow).toBeDefined()
+			expect(Array.isArray(doctype.workflow?.states)).toBe(true)
+
+			const draftTransitions = doctype.getAvailableTransitions('draft')
+			expect(draftTransitions).toHaveLength(1)
+			expect(draftTransitions[0].name).toBe('submit')
+
+			const submittedTransitions = doctype.getAvailableTransitions('submitted')
+			expect(submittedTransitions).toHaveLength(1)
+			expect(submittedTransitions[0].name).toBe('approve')
+		})
+
+		it('accepts XState UnknownMachineConfig format for workflow', () => {
+			const obj = {
+				name: 'Task',
+				workflow: {
+					id: 'task',
+					initial: 'todo',
+					states: {
+						todo: { on: { START: 'in_progress' } },
+						in_progress: { on: { COMPLETE: 'done' } },
+						done: { type: 'final' as const },
+					},
+				} as UnknownMachineConfig,
+			}
+
+			const doctype = Doctype.fromObject(obj)
+
+			expect(doctype.workflow).toBeDefined()
+			expect(typeof (doctype.workflow as UnknownMachineConfig).states).toBe('object')
+			expect(doctype.getAvailableTransitions('todo')).toEqual([{ name: 'START', targetState: 'in_progress' }])
+		})
 	})
 
 	describe('getSchemaArray', () => {
@@ -360,6 +481,64 @@ describe('Doctype class', () => {
 				save: ['validateData', 'saveData'],
 				delete: ['confirmDelete', 'deleteData'],
 			})
+		})
+	})
+
+	describe('getActionMeta', () => {
+		it('returns action metadata from WorkflowMeta format', () => {
+			const workflowMeta: WorkflowMeta = {
+				states: ['draft', 'submitted'],
+				actions: {
+					submit: {
+						label: 'Submit for Review',
+						handler: 'plan:submit',
+						requiredFields: ['title', 'description'],
+						allowedStates: ['draft'],
+						confirm: true,
+						args: { notify: true },
+					},
+				},
+			}
+			const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+			const meta = doctype.getActionMeta('submit')
+			expect(meta).toEqual({
+				label: 'Submit for Review',
+				handler: 'plan:submit',
+				requiredFields: ['title', 'description'],
+				allowedStates: ['draft'],
+				confirm: true,
+				args: { notify: true },
+			})
+		})
+
+		it('returns undefined for unknown action', () => {
+			const workflowMeta: WorkflowMeta = {
+				states: ['draft'],
+				actions: { submit: { label: 'Submit', handler: 'submit' } },
+			}
+			const doctype = new Doctype('Plan', mockSchema, workflowMeta, mockActions)
+
+			expect(doctype.getActionMeta('unknown')).toBeUndefined()
+		})
+
+		it('returns undefined for XState format workflow', () => {
+			const doctype = new Doctype('Task', mockSchema, mockWorkflow, mockActions)
+
+			expect(doctype.getActionMeta('load')).toBeUndefined()
+		})
+
+		it('returns undefined when workflow is undefined', () => {
+			const doctype = new Doctype('Task', mockSchema, undefined, mockActions)
+
+			expect(doctype.getActionMeta('submit')).toBeUndefined()
+		})
+
+		it('returns undefined when workflow has no actions', () => {
+			const workflowMeta: WorkflowMeta = { states: ['draft'] }
+			const doctype = new Doctype('Task', mockSchema, workflowMeta, mockActions)
+
+			expect(doctype.getActionMeta('submit')).toBeUndefined()
 		})
 	})
 })

--- a/stonecrop/tests/stonecrop.spec.ts
+++ b/stonecrop/tests/stonecrop.spec.ts
@@ -429,6 +429,77 @@ describe('Stonecrop class with HST integration', () => {
 			const state = stonecrop.getRecordState('task', 'ghost')
 			expect(state).toBe('draft')
 		})
+
+		describe('WorkflowMeta format support', () => {
+			it('returns first state as initial for WorkflowMeta format', () => {
+				Registry._root = undefined as any
+				const localRegistry = new Registry()
+				const localStonecrop = new Stonecrop(localRegistry)
+
+				const workflowMeta = {
+					states: ['planning', 'review', 'approved'],
+					actions: {
+						submit: { label: 'Submit', handler: 'plan:submit', allowedStates: ['planning'] },
+					},
+				}
+				const planDoctype = new Doctype('Plan', List<SchemaTypes>([]), workflowMeta, Map({}))
+				localRegistry.addDoctype(planDoctype)
+				localStonecrop.addRecord('plan', 'p-1', { id: 'p-1' })
+
+				const state = localStonecrop.getRecordState('plan', 'p-1')
+				expect(state).toBe('planning')
+			})
+
+			it('returns status field when present, regardless of workflow format', () => {
+				Registry._root = undefined as any
+				const localRegistry = new Registry()
+				const localStonecrop = new Stonecrop(localRegistry)
+
+				const workflowMeta = {
+					states: ['planning', 'review', 'approved'],
+					actions: {},
+				}
+				const planDoctype = new Doctype('Plan', List<SchemaTypes>([]), workflowMeta, Map({}))
+				localRegistry.addDoctype(planDoctype)
+				localStonecrop.addRecord('plan', 'p-2', { id: 'p-2', status: 'review' })
+
+				const state = localStonecrop.getRecordState('plan', 'p-2')
+				expect(state).toBe('review')
+			})
+
+			it('handles WorkflowMeta with empty states array', () => {
+				Registry._root = undefined as any
+				const localRegistry = new Registry()
+				const localStonecrop = new Stonecrop(localRegistry)
+
+				const emptyStatesMeta = {
+					states: [],
+					actions: {},
+				}
+				const doctype = new Doctype('Empty', List<SchemaTypes>([]), emptyStatesMeta, Map({}))
+				localRegistry.addDoctype(doctype)
+				localStonecrop.addRecord('empty', 'e-1', { id: 'e-1' })
+
+				const state = localStonecrop.getRecordState('empty', 'e-1')
+				expect(state).toBe('')
+			})
+
+			it('handles WorkflowMeta without states property', () => {
+				Registry._root = undefined as any
+				const localRegistry = new Registry()
+				const localStonecrop = new Stonecrop(localRegistry)
+
+				const noStatesMeta = {
+					actions: { save: { label: 'Save', handler: 'save' } },
+				}
+				const doctype = new Doctype('NoStates', List<SchemaTypes>([]), noStatesMeta, Map({}))
+				localRegistry.addDoctype(doctype)
+				localStonecrop.addRecord('no-states', 'ns-1', { id: 'ns-1' })
+
+				const state = localStonecrop.getRecordState('no-states', 'ns-1')
+				expect(state).toBe('')
+			})
+		})
 	})
 
 	describe('Advanced HST Usage', () => {


### PR DESCRIPTION
There's two issues this is solving.

---

**Observed**: `Doctype.fromObject()` expects `workflow` to be an XState `UnknownMachineConfig`, but `StonecropClient.getMeta()` returns `DoctypeMeta` from `@stonecrop/schema` which has `workflow` as `WorkflowMeta` (a simpler format with `states?: string[]` and `actions?: Record<string, ActionDefinition>`).

**Type definitions**:

```ts
// @stonecrop/schema - WorkflowMeta (returned by getMeta)
interface WorkflowMeta {
  states?: string[]
  actions?: Record<string, {
    label: string
    handler: string
    requiredFields?: string[]
    allowedStates?: string[]
    confirm?: boolean
    args?: Record<string, unknown>
  }>
}

// @stonecrop/stonecrop - DoctypeConfig (expected by fromObject)
interface DoctypeConfig {
  workflow?: UnknownMachineConfig // XState format - different structure!
}
```

**Root cause**: The two packages define workflow differently:
- `@stonecrop/schema` uses a simple, serializable format for API responses
- `@stonecrop/stonecrop` expects XState machine configs for runtime behavior

**Workaround applied in fab**: Omit `workflow` when calling `Doctype.fromObject()` since fab uses local JSON files for workflow actions. See `toDoctypeConfig()` helper in `stonecrop.client.ts`.

**Solution implemented**: `Doctype.fromObject()` now accepts both `WorkflowMeta` (simple format) and `UnknownMachineConfig` (XState format). The `getAvailableTransitions()` method detects the format and handles both correctly. A new `getActionMeta()` method was added to retrieve action metadata from `WorkflowMeta` format.

---

**Observed**: In Nuxt 4, user plugins run before module plugins by default. Apps can use `dependsOn: ['plugin-name']` to wait for another plugin, but `@stonecrop/nuxt`'s runtime plugin has no `name` property.

Additionally, `useStonecropSetup()` throws immediately if `$registry`/`$stonecrop` aren't available, making it unusable without guaranteed plugin ordering.

**Why not merge plugin into composable?**
Vue plugins (AForm, NodeEditor, Pinia, Stonecrop) must be installed during app creation via `app.use()` - that's what Nuxt plugins are for. Composables run in component context and can't properly handle Vue plugin installation. Merging would violate Vue conventions and cause component availability issues.

**Solution implemented**: Added `name: 'stonecrop'` to the Nuxt plugin definition, enabling Nuxt 4 `dependsOn` support for plugin ordering.