### PR TITLE
[graphql_client] [stonecrop] update input types for client methods

### DIFF
--- a/common/changes/@stonecrop/graphql-client/fix-graphql-client-typings_2026-03-19-11-19.json
+++ b/common/changes/@stonecrop/graphql-client/fix-graphql-client-typings_2026-03-19-11-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-client",
+      "comment": "update return typings for client methods",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-client"
+}

--- a/common/changes/@stonecrop/nuxt/fix-graphql-client-typings_2026-03-19-11-19.json
+++ b/common/changes/@stonecrop/nuxt/fix-graphql-client-typings_2026-03-19-11-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/nuxt",
+      "comment": "update return format on nuxt plugin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/nuxt"
+}

--- a/common/reviews/api/graphql-client.api.md
+++ b/common/reviews/api/graphql-client.api.md
@@ -7,6 +7,7 @@
 import type { DataClient } from '@stonecrop/schema';
 import type { DoctypeContext } from '@stonecrop/schema';
 import { DoctypeMeta } from '@stonecrop/schema';
+import type { DoctypeRef } from '@stonecrop/schema';
 
 export { DoctypeContext }
 
@@ -62,8 +63,8 @@ export class StonecropClient implements DataClient {
     clearMetaCache(): void;
     getAllMeta(): Promise<DoctypeMeta[]>;
     getMeta(context: DoctypeContext): Promise<DoctypeMeta | null>;
-    getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknown> | null>;
-    getRecords(doctype: DoctypeMeta, options?: {
+    getRecord(doctype: DoctypeRef, recordId: string): Promise<Record<string, unknown> | null>;
+    getRecords(doctype: DoctypeRef, options?: {
         filters?: Record<string, unknown>;
         orderBy?: string;
         limit?: number;
@@ -71,7 +72,7 @@ export class StonecropClient implements DataClient {
     }): Promise<Record<string, unknown>[]>;
     mutate<T = unknown>(mutation: string, variables?: Record<string, unknown>): Promise<T>;
     query<T = unknown>(query: string, variables?: Record<string, unknown>): Promise<T>;
-    runAction(doctype: DoctypeMeta, action: string, args?: unknown[]): Promise<{
+    runAction(doctype: DoctypeRef, action: string, args?: unknown[]): Promise<{
         success: boolean;
         data: unknown;
         error: string | null;

--- a/docs/guides/desktop-integration.md
+++ b/docs/guides/desktop-integration.md
@@ -235,36 +235,3 @@ stonecrop.value.addRecord(payload.doctype, payload.recordId, {
   // status: 'submitted' — Desktop will now show APPROVE / REJECT buttons
 })
 ```
-
----
-
-## New APIs Added in PR 3
-
-These methods were added to the stonecrop package to support Desktop's integration pattern. They can be used directly by host applications too:
-
-### `Registry.getDoctype(slug)`
-
-```typescript
-const meta = stonecrop.value.registry.getDoctype('plan')
-// Returns DoctypeMeta | undefined
-```
-
-Look up a registered doctype by slug. Prefer this over `registry.registry[slug]` (internal implementation detail).
-
-### `DoctypeMeta.getAvailableTransitions(currentState)`
-
-```typescript
-const transitions = meta.getAvailableTransitions('draft')
-// [{ name: 'SUBMIT', targetState: 'submitted' }, ...]
-```
-
-Returns the transitions available from a given workflow state directly from the XState config. Useful for rendering action menus without replicating workflow introspection logic.
-
-### `Stonecrop.getRecordState(doctype, recordId)`
-
-```typescript
-const state = stonecrop.value.getRecordState('plan', 'plan-123')
-// 'draft' — reads from HST status field, falls back to workflow.initial
-```
-
-Returns the current FSM state for a record. Centralises the convention that `status` holds the FSM state and ensures consistent fallback behaviour.

--- a/docs/reference/graphql-client.md
+++ b/docs/reference/graphql-client.md
@@ -153,14 +153,14 @@ getMeta(context: DoctypeContext): Promise<DoctypeMeta | null>
 Get a single record by ID
 
 ```typescript
-getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknown> | null>
+getRecord(doctype: DoctypeRef, recordId: string): Promise<Record<string, unknown> | null>
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | recordId | `string` | Record ID to fetch |
 
 #### getRecords
@@ -168,7 +168,7 @@ getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknow
 Get multiple records with optional filtering and pagination
 
 ```typescript
-getRecords(doctype: DoctypeMeta, options: {
+getRecords(doctype: DoctypeRef, options: {
         filters?: Record<string, unknown>;
         orderBy?: string;
         limit?: number;
@@ -180,7 +180,7 @@ getRecords(doctype: DoctypeMeta, options: {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | options | `{ filters?: Record<string, unknown>; orderBy?: string; limit?: number; offset?: number; }` | Query options (filters, orderBy, limit, offset) |
 
 #### mutate
@@ -218,7 +218,7 @@ query(query: string, variables: Record<string, unknown>): Promise<T>
 Execute a doctype action
 
 ```typescript
-runAction(doctype: DoctypeMeta, action: string, args: unknown[]): Promise<{
+runAction(doctype: DoctypeRef, action: string, args: unknown[]): Promise<{
         success: boolean;
         data: unknown;
         error: string | null;
@@ -229,7 +229,7 @@ runAction(doctype: DoctypeMeta, action: string, args: unknown[]): Promise<{
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | action | `string` | Action name to execute |
 | args | `unknown[]` | Action arguments |
 

--- a/graphql_client/api.md
+++ b/graphql_client/api.md
@@ -148,14 +148,14 @@ getMeta(context: DoctypeContext): Promise<DoctypeMeta | null>
 Get a single record by ID
 
 ```typescript
-getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknown> | null>
+getRecord(doctype: DoctypeRef, recordId: string): Promise<Record<string, unknown> | null>
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | recordId | `string` | Record ID to fetch |
 
 #### getRecords
@@ -163,7 +163,7 @@ getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknow
 Get multiple records with optional filtering and pagination
 
 ```typescript
-getRecords(doctype: DoctypeMeta, options: {
+getRecords(doctype: DoctypeRef, options: {
         filters?: Record<string, unknown>;
         orderBy?: string;
         limit?: number;
@@ -175,7 +175,7 @@ getRecords(doctype: DoctypeMeta, options: {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | options | `{ filters?: Record<string, unknown>; orderBy?: string; limit?: number; offset?: number; }` | Query options (filters, orderBy, limit, offset) |
 
 #### mutate
@@ -213,7 +213,7 @@ query(query: string, variables: Record<string, unknown>): Promise<T>
 Execute a doctype action
 
 ```typescript
-runAction(doctype: DoctypeMeta, action: string, args: unknown[]): Promise<{
+runAction(doctype: DoctypeRef, action: string, args: unknown[]): Promise<{
         success: boolean;
         data: unknown;
         error: string | null;
@@ -224,7 +224,7 @@ runAction(doctype: DoctypeMeta, action: string, args: unknown[]): Promise<{
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `DoctypeMeta` | Doctype metadata |
+| doctype | `DoctypeRef` | Doctype reference (name and optional slug) |
 | action | `string` | Action name to execute |
 | args | `unknown[]` | Action arguments |
 

--- a/graphql_client/src/client.ts
+++ b/graphql_client/src/client.ts
@@ -1,6 +1,6 @@
-import type { DataClient, DoctypeMeta, DoctypeContext } from '@stonecrop/schema'
+import type { DataClient, DoctypeMeta, DoctypeContext, DoctypeRef } from '@stonecrop/schema'
 
-export type { DoctypeContext }
+export type { DoctypeContext, DoctypeRef }
 
 /**
  * Options for creating a Stonecrop client
@@ -99,7 +99,14 @@ export class StonecropClient implements DataClient {
 					}
 					workflow {
 						states
-						actions
+						actions {
+							label
+							handler
+							requiredFields
+							allowedStates
+							confirm
+							args
+						}
 					}
 					inherits
 					listDoctype
@@ -149,7 +156,14 @@ export class StonecropClient implements DataClient {
 					}
 					workflow {
 						states
-						actions
+						actions {
+							label
+							handler
+							requiredFields
+							allowedStates
+							confirm
+							args
+						}
 					}
 					inherits
 					listDoctype
@@ -168,10 +182,10 @@ export class StonecropClient implements DataClient {
 
 	/**
 	 * Get a single record by ID
-	 * @param doctype - Doctype metadata
+	 * @param doctype - Doctype reference (name and optional slug)
 	 * @param recordId - Record ID to fetch
 	 */
-	async getRecord(doctype: DoctypeMeta, recordId: string): Promise<Record<string, unknown> | null> {
+	async getRecord(doctype: DoctypeRef, recordId: string): Promise<Record<string, unknown> | null> {
 		const result = await this.query<{
 			stonecropRecord: { data: Record<string, unknown> | null }
 		}>(
@@ -190,11 +204,11 @@ export class StonecropClient implements DataClient {
 
 	/**
 	 * Get multiple records with optional filtering and pagination
-	 * @param doctype - Doctype metadata
+	 * @param doctype - Doctype reference (name and optional slug)
 	 * @param options - Query options (filters, orderBy, limit, offset)
 	 */
 	async getRecords(
-		doctype: DoctypeMeta,
+		doctype: DoctypeRef,
 		options?: {
 			filters?: Record<string, unknown>
 			orderBy?: string
@@ -236,12 +250,12 @@ export class StonecropClient implements DataClient {
 
 	/**
 	 * Execute a doctype action
-	 * @param doctype - Doctype metadata
+	 * @param doctype - Doctype reference (name and optional slug)
 	 * @param action - Action name to execute
 	 * @param args - Action arguments
 	 */
 	async runAction(
-		doctype: DoctypeMeta,
+		doctype: DoctypeRef,
 		action: string,
 		args?: unknown[]
 	): Promise<{ success: boolean; data: unknown; error: string | null }> {

--- a/graphql_client/tests/client.test.ts
+++ b/graphql_client/tests/client.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { StonecropClient } from '../src/client'
+import type { DoctypeRef, DoctypeMeta } from '@stonecrop/schema'
+
+interface GraphQLRequestBody {
+	query: string
+	variables?: Record<string, unknown>
+}
 
 // ---------------------------------------------------------------------------
 // Fetch mock helpers
@@ -29,7 +35,9 @@ afterEach(() => {
 
 const ENDPOINT = 'http://localhost/graphql'
 
-const taskMeta = {
+const taskRef: DoctypeRef = { name: 'Task' }
+
+const taskMeta: DoctypeMeta = {
 	name: 'Task',
 	tableName: 'tasks',
 	fields: [
@@ -56,7 +64,7 @@ describe('StonecropClient constructor', () => {
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropMeta: null }))
 		await client.getMeta({ doctype: 'Task' })
 
-		const [, options] = mockFetch.mock.calls[0]
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
 		const headers = options.headers as Record<string, string>
 		expect(headers['Authorization']).toBe('Bearer token123')
 		expect(headers['Content-Type']).toBe('application/json')
@@ -75,10 +83,10 @@ describe('StonecropClient.query', () => {
 		const result = await client.query('query { foo }', { bar: 1 })
 
 		expect(mockFetch).toHaveBeenCalledOnce()
-		const [url, options] = mockFetch.mock.calls[0]
+		const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
 		expect(url).toBe(ENDPOINT)
 		expect(options.method).toBe('POST')
-		const body = JSON.parse(options.body as string)
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
 		expect(body.query).toBe('query { foo }')
 		expect(body.variables).toEqual({ bar: 1 })
 		expect(result).toEqual({ result: 42 })
@@ -89,8 +97,8 @@ describe('StonecropClient.query', () => {
 		mockFetch.mockReturnValue(makeFetchResponse({ x: 1 }))
 		await client.query('query { x }')
 
-		const [, options] = mockFetch.mock.calls[0]
-		const body = JSON.parse(options.body as string)
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
 		expect(body.variables).toBeUndefined()
 	})
 
@@ -156,9 +164,9 @@ describe('StonecropClient.getMeta', () => {
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropMeta: taskMeta }))
 		await client.getMeta({ doctype: 'Task' })
 
-		const [, options] = mockFetch.mock.calls[0]
-		const body = JSON.parse(options.body as string)
-		expect(body.variables.doctype).toBe('Task')
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
+		expect(body.variables!.doctype).toBe('Task')
 	})
 })
 
@@ -199,26 +207,26 @@ describe('StonecropClient.getRecord', () => {
 		const record = { id: '42', title: 'Write tests' }
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecord: { data: record } }))
 
-		const result = await client.getRecord(taskMeta as any, '42')
+		const result = await client.getRecord(taskRef, '42')
 		expect(result).toEqual(record)
 	})
 
 	it('returns null when record is null', async () => {
 		const client = new StonecropClient({ endpoint: ENDPOINT })
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecord: { data: null } }))
-		const result = await client.getRecord(taskMeta as any, '999')
+		const result = await client.getRecord(taskRef, '999')
 		expect(result).toBeNull()
 	})
 
 	it('sends correct variables to the server', async () => {
 		const client = new StonecropClient({ endpoint: ENDPOINT })
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecord: { data: null } }))
-		await client.getRecord(taskMeta as any, 'record-id-1')
+		await client.getRecord(taskRef, 'record-id-1')
 
-		const [, options] = mockFetch.mock.calls[0]
-		const body = JSON.parse(options.body as string)
-		expect(body.variables.doctype).toBe('Task')
-		expect(body.variables.id).toBe('record-id-1')
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
+		expect(body.variables!.doctype).toBe('Task')
+		expect(body.variables!.id).toBe('record-id-1')
 	})
 })
 
@@ -232,7 +240,7 @@ describe('StonecropClient.getRecords', () => {
 		const records = [{ id: '1' }, { id: '2' }]
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecords: { data: records, count: 2 } }))
 
-		const result = await client.getRecords(taskMeta as any)
+		const result = await client.getRecords(taskRef)
 		expect(result).toHaveLength(2)
 	})
 
@@ -240,25 +248,25 @@ describe('StonecropClient.getRecords', () => {
 		const client = new StonecropClient({ endpoint: ENDPOINT })
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecords: { data: [], count: 0 } }))
 
-		await client.getRecords(taskMeta as any, {
+		await client.getRecords(taskRef, {
 			limit: 10,
 			offset: 5,
 			orderBy: 'title_ASC',
 			filters: { status: 'open' },
 		})
 
-		const [, options] = mockFetch.mock.calls[0]
-		const body = JSON.parse(options.body as string)
-		expect(body.variables.limit).toBe(10)
-		expect(body.variables.offset).toBe(5)
-		expect(body.variables.orderBy).toBe('title_ASC')
-		expect(body.variables.filters).toEqual({ status: 'open' })
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
+		expect(body.variables!.limit).toBe(10)
+		expect(body.variables!.offset).toBe(5)
+		expect(body.variables!.orderBy).toBe('title_ASC')
+		expect(body.variables!.filters).toEqual({ status: 'open' })
 	})
 
 	it('works with no options (defaults)', async () => {
 		const client = new StonecropClient({ endpoint: ENDPOINT })
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropRecords: { data: [], count: 0 } }))
-		const result = await client.getRecords(taskMeta as any)
+		const result = await client.getRecords(taskRef)
 		expect(result).toEqual([])
 	})
 })
@@ -276,7 +284,7 @@ describe('StonecropClient.runAction', () => {
 			})
 		)
 
-		const result = await client.runAction(taskMeta as any, 'submit', [{ id: '1' }])
+		const result = await client.runAction(taskRef, 'submit', [{ id: '1' }])
 		expect(result.success).toBe(true)
 		expect(result.data).toEqual({ updated: true })
 		expect(result.error).toBeNull()
@@ -290,7 +298,7 @@ describe('StonecropClient.runAction', () => {
 			})
 		)
 
-		const result = await client.runAction(taskMeta as any, 'submit')
+		const result = await client.runAction(taskRef, 'submit')
 		expect(result.success).toBe(false)
 		expect(result.error).toBe('Action failed')
 	})
@@ -299,13 +307,13 @@ describe('StonecropClient.runAction', () => {
 		const client = new StonecropClient({ endpoint: ENDPOINT })
 		mockFetch.mockReturnValue(makeFetchResponse({ stonecropAction: { success: true, data: null, error: null } }))
 
-		await client.runAction(taskMeta as any, 'cancel', ['arg1', 'arg2'])
+		await client.runAction(taskRef, 'cancel', ['arg1', 'arg2'])
 
-		const [, options] = mockFetch.mock.calls[0]
-		const body = JSON.parse(options.body as string)
-		expect(body.variables.doctype).toBe('Task')
-		expect(body.variables.action).toBe('cancel')
-		expect(body.variables.args).toEqual(['arg1', 'arg2'])
+		const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+		const body = JSON.parse(options.body as string) as GraphQLRequestBody
+		expect(body.variables!.doctype).toBe('Task')
+		expect(body.variables!.action).toBe('cancel')
+		expect(body.variables!.args).toEqual(['arg1', 'arg2'])
 	})
 })
 

--- a/nuxt/src/runtime/plugin.ts
+++ b/nuxt/src/runtime/plugin.ts
@@ -1,6 +1,6 @@
 import { install as AForm } from '@stonecrop/aform'
 import { install as NodeEditor } from '@stonecrop/node-editor'
-import StonecropPlugin from '@stonecrop/stonecrop'
+import StonecropPlugin, { type Registry, type Stonecrop } from '@stonecrop/stonecrop'
 import { createPinia } from 'pinia'
 
 import { defineNuxtPlugin, useRouter } from 'nuxt/app'
@@ -21,5 +21,18 @@ export default defineNuxtPlugin({
 		app.use(AForm)
 		app.use(NodeEditor)
 		app.use(StonecropPlugin, { router })
+
+		// Extract from globalProperties (set by Stonecrop Vue plugin)
+		const registry = app.config.globalProperties.$registry as Registry
+		const stonecrop = app.config.globalProperties.$stonecrop as Stonecrop
+
+		// Provide via Nuxt's mechanism so useStonecropSetup() works
+		// This sets getters on BOTH nuxtApp.$registry AND nuxtApp.vueApp.config.globalProperties.$registry
+		return {
+			provide: {
+				registry,
+				stonecrop,
+			},
+		}
 	},
 })


### PR DESCRIPTION
**Symptom**: Even with `dependsOn: ['stonecrop']`, calling `useStonecropSetup()` in a user plugin throws "Registry not available".

**Root cause analysis**:

Nuxt's `nuxtApp.provide(name, value)` sets getters on BOTH:
1. `nuxtApp.$name` 
2. `nuxtApp.vueApp.config.globalProperties.$name`

But the `@stonecrop/stonecrop` Vue plugin uses Vue's native mechanisms:
- `app.provide('$registry', registry)` — Vue's provide/inject
- `app.config.globalProperties.$registry = registry` — Vue's global properties

**The disconnect**: The Vue plugin sets `vueApp.config.globalProperties.$registry`, but NOT `nuxtApp.$registry`. These are different properties!

`useStonecropSetup()` accesses `nuxtApp.$registry`, which was never set because the Stonecrop Vue plugin bypasses Nuxt's `provide()` mechanism.

**Solution implemented**: 

Modified `@stonecrop/nuxt/runtime/plugin.ts` to return `{ provide: { registry, stonecrop } }` from its setup function. This way:
1. Nuxt's `applyPlugin()` will call `nuxtApp.provide('registry', registry)` 
2. Both `nuxtApp.$registry` AND `nuxtApp.vueApp.config.globalProperties.$registry` will be set
3. `useStonecropSetup()` will work as expected