### PR TITLE
[aform] [stonecrop] allow 1:1 and 1:many doctype schema maps

### DIFF
--- a/aform/api.md
+++ b/aform/api.md
@@ -110,6 +110,22 @@ declare function install(app: App): void;
 |-----------|------|-------------|
 | app | `App` | Vue app instance |
 
+### isDoctypeMany
+
+Type guard that checks whether a Doctype schema field has `cardinality: 'many'`
+
+**Signature:**
+
+```typescript
+export declare function isDoctypeMany(field: DoctypeSchema): field is DoctypeManySchema;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| field | `DoctypeSchema` | A DoctypeSchema field to check |
+
 ## Type Aliases
 
 ### BaseSchema
@@ -147,19 +163,49 @@ export type ComponentProps = {
 };
 ```
 
-### DoctypeSchema
+### DoctypeManySchema
 
-Schema structure for defining nested doctype fields inside AForm
+Schema structure for a 1:many child table field inside AForm
 
 **Definition:**
 
 ```typescript
-export type DoctypeSchema = BaseSchema & {
+export type DoctypeManySchema = BaseSchema & {
     fieldtype: 'Doctype';
     options: string;
     label?: string;
+    cardinality: 'many';
+    columns?: TableColumn[];
+    config?: TableConfig;
+    rows?: TableRow[];
+    component?: string;
+};
+```
+
+### DoctypeOneSchema
+
+Schema structure for a 1:1 nested doctype field inside AForm
+
+**Definition:**
+
+```typescript
+export type DoctypeOneSchema = BaseSchema & {
+    fieldtype: 'Doctype';
+    options: string;
+    label?: string;
+    cardinality?: 'one';
     schema?: SchemaTypes[];
 };
+```
+
+### DoctypeSchema
+
+Discriminated union for Doctype fields — either 1:1 nested form or 1:many child table
+
+**Definition:**
+
+```typescript
+export type DoctypeSchema = DoctypeOneSchema | DoctypeManySchema;
 ```
 
 ### FieldsetSchema
@@ -211,24 +257,7 @@ Superset of all schema types for AForm
 **Definition:**
 
 ```typescript
-export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema | TableDoctypeSchema;
-```
-
-### TableDoctypeSchema
-
-Schema structure for defining 1:many child table fields inside AForm
-
-**Definition:**
-
-```typescript
-export type TableDoctypeSchema = BaseSchema & {
-    fieldtype: 'Table';
-    options: string;
-    label?: string;
-    columns?: TableColumn[];
-    config?: TableConfig;
-    rows?: TableRow[];
-};
+export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema;
 ```
 
 ### TableSchema

--- a/aform/src/index.ts
+++ b/aform/src/index.ts
@@ -14,6 +14,7 @@ import ANumericInput from './components/form/ANumericInput.vue'
 import ATextInput from './components/form/ATextInput.vue'
 import Login from './components/utilities/Login.vue'
 export type * from './types'
+export { isDoctypeMany } from './utils/doctype'
 
 /**
  * Install all AForm components
@@ -22,8 +23,9 @@ export type * from './types'
  */
 function install(app: App /* options */) {
 	app.use(installATable) // Install ATable components for use within AForm
+
 	app.component('ACheckbox', ACheckbox)
-	app.component('ACombobox', AComboBox)
+	app.component('AComboBox', AComboBox)
 	app.component('ADate', ADate)
 	app.component('ADropdown', ADropdown)
 	app.component('ADatePicker', ADatePicker)

--- a/aform/src/types/index.ts
+++ b/aform/src/types/index.ts
@@ -194,12 +194,13 @@ export type FieldsetSchema = BaseSchema & {
 }
 
 /**
- * Schema structure for defining nested doctype fields inside AForm
+ * Schema structure for a 1:1 nested doctype field inside AForm
  *
  * @remarks
- * When a field has `fieldtype: 'Doctype'`, the `options` property contains the slug
- * of the referenced doctype. The `schema` property is populated by the framework's
- * `registry.resolveSchema()` method with the resolved child schema fields.
+ * When a field has `fieldtype: 'Doctype'` without `cardinality: 'many'`, it represents
+ * a 1:1 nested form. The `options` property contains the slug of the referenced doctype.
+ * The `schema` property is populated by the framework's `registry.resolveSchema()` method
+ * with the resolved child schema fields.
  *
  * Before resolution: `{ fieldname: 'address', fieldtype: 'Doctype', options: 'address' }`
  * After resolution: `{ fieldname: 'address', fieldtype: 'Doctype', options: 'address', schema: [...resolved fields...] }`
@@ -208,7 +209,7 @@ export type FieldsetSchema = BaseSchema & {
  *
  * @public
  */
-export type DoctypeSchema = BaseSchema & {
+export type DoctypeOneSchema = BaseSchema & {
 	/**
 	 * The field type - must be 'Doctype' for nested doctype fields
 	 * @public
@@ -228,6 +229,12 @@ export type DoctypeSchema = BaseSchema & {
 	label?: string
 
 	/**
+	 * The cardinality of the relationship — `'one'` or omitted means 1:1 nested form
+	 * @public
+	 */
+	cardinality?: 'one'
+
+	/**
 	 * The resolved child schema fields, populated by `registry.resolveSchema()`
 	 * or provided manually for standalone usage
 	 * @public
@@ -236,11 +243,12 @@ export type DoctypeSchema = BaseSchema & {
 }
 
 /**
- * Schema structure for defining 1:many child table fields inside AForm
+ * Schema structure for a 1:many child table field inside AForm
  *
  * @remarks
- * When a field has `fieldtype: 'Table'`, the `options` property contains the slug
- * of the child doctype whose records appear as table rows.
+ * When a field has `fieldtype: 'Doctype'` with `cardinality: 'many'`, it represents
+ * a 1:many child table. The `options` property contains the slug of the child doctype
+ * whose records appear as table rows.
  *
  * `Registry.resolveSchema()` auto-derives `columns` from the child doctype's schema
  * fields and sets sensible defaults for `component` (`'ATable'`) and `config` (`{ view: 'list' }`).
@@ -250,12 +258,12 @@ export type DoctypeSchema = BaseSchema & {
  *
  * @public
  */
-export type TableDoctypeSchema = BaseSchema & {
+export type DoctypeManySchema = BaseSchema & {
 	/**
-	 * The field type — must be 'Table' for 1:many child table fields
+	 * The field type - must be 'Doctype' for nested doctype fields
 	 * @public
 	 */
-	fieldtype: 'Table'
+	fieldtype: 'Doctype'
 
 	/**
 	 * The slug of the child doctype in the registry
@@ -268,6 +276,12 @@ export type TableDoctypeSchema = BaseSchema & {
 	 * @public
 	 */
 	label?: string
+
+	/**
+	 * The cardinality of the relationship — `'many'` means 1:many child table
+	 * @public
+	 */
+	cardinality: 'many'
 
 	/**
 	 * Table columns — auto-derived from child doctype schema if not provided
@@ -286,10 +300,27 @@ export type TableDoctypeSchema = BaseSchema & {
 	 * @public
 	 */
 	rows?: TableRow[]
+
+	/**
+	 * The component to render — defaults to `'ATable'` when resolved
+	 * @public
+	 */
+	component?: string
 }
+
+/**
+ * Discriminated union for Doctype fields — either 1:1 nested form or 1:many child table
+ *
+ * @remarks
+ * Use `isDoctypeMany()` type guard to narrow to `DoctypeManySchema`.
+ * When `cardinality` is `'many'` or omitted, the field is a 1:1 nested form.
+ *
+ * @public
+ */
+export type DoctypeSchema = DoctypeOneSchema | DoctypeManySchema
 
 /**
  * Superset of all schema types for AForm
  * @public
  */
-export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema | TableDoctypeSchema
+export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema

--- a/aform/src/utils/doctype.ts
+++ b/aform/src/utils/doctype.ts
@@ -1,0 +1,12 @@
+import type { DoctypeSchema, DoctypeManySchema } from '../types'
+
+/**
+ * Type guard that checks whether a Doctype schema field has `cardinality: 'many'`
+ *
+ * @param field - A DoctypeSchema field to check
+ * @returns `true` if the field has `cardinality: 'many'`
+ * @public
+ */
+export function isDoctypeMany(field: DoctypeSchema): field is DoctypeManySchema {
+	return field.cardinality === 'many'
+}

--- a/aform/tests/combobox.spec.ts
+++ b/aform/tests/combobox.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import AComboBox from '../src/components/form/AComboBox.vue'
+
+describe('combobox component', () => {
+	it('renders with three input fields', () => {
+		const wrapper = mount(AComboBox, {
+			global: {
+				stubs: {
+					ATableModal: {
+						template: '<div class="amodal"><slot /></div>',
+						props: ['event', 'cellData'],
+					},
+				},
+			},
+			props: {
+				event: {},
+				cellData: {},
+				tableID: 'test-table',
+			},
+		})
+
+		expect(wrapper.find('.amodal').exists()).toBe(true)
+		const inputs = wrapper.findAll('input')
+		expect(inputs.length).toBe(3)
+	})
+
+	it('passes props to ATableModal', () => {
+		const eventData = { target: {} }
+		const cellData = { value: 'test' }
+
+		const wrapper = mount(AComboBox, {
+			global: {
+				stubs: {
+					ATableModal: {
+						template: '<div class="amodal"><slot /></div>',
+						props: ['event', 'cellData'],
+					},
+				},
+			},
+			props: {
+				event: eventData,
+				cellData: cellData,
+				tableID: 'test-table',
+			},
+		})
+
+		expect(wrapper.find('.amodal').exists()).toBe(true)
+	})
+})

--- a/aform/tests/dropdown.spec.ts
+++ b/aform/tests/dropdown.spec.ts
@@ -339,4 +339,27 @@ describe('dropdown input component', () => {
 		expect(wrapper.find('input').exists()).toBe(false)
 		expect(wrapper.find('.aform_display-value').text()).toBe('Apple')
 	})
+
+	it('selectPrevResult decrements index when currentIndex > 0', async () => {
+		const wrapper = mount(ADropdown, {
+			props: { modelValue: '', label: dropdownData.label, options: dropdownData.options },
+		})
+
+		const input = wrapper.find('input')
+		await input.trigger('focus')
+		await input.setValue('')
+		await flushPromises()
+		await wrapper.vm.$nextTick()
+
+		await input.trigger('keydown.down')
+		await input.trigger('keydown.down')
+		await input.trigger('keydown.up')
+		await input.trigger('keydown.enter')
+		await wrapper.vm.$nextTick()
+
+		const updateEvents = wrapper.emitted('update:modelValue')
+		expect(updateEvents).toBeTruthy()
+		const lastEvent = updateEvents![updateEvents!.length - 1]
+		expect(lastEvent).toEqual(['Apple'])
+	})
 })

--- a/aform/tests/fileattach.spec.ts
+++ b/aform/tests/fileattach.spec.ts
@@ -1,9 +1,38 @@
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref, Ref } from 'vue'
+
+const mockFiles: Ref<FileList | null> = ref(null)
+
+vi.mock('@vueuse/core', () => ({
+	useFileDialog: () => ({
+		files: mockFiles,
+		open: vi.fn(),
+		reset: vi.fn(() => {
+			mockFiles.value = null
+		}),
+		onChange: vi.fn(),
+	}),
+}))
 
 import AFileAttach from '../src/components/form/AFileAttach.vue'
 
+function createFileList(files: File[]): FileList {
+	return {
+		...files,
+		length: files.length,
+		item: (index: number) => files[index],
+		[Symbol.iterator]: function* () {
+			for (const file of files) yield file
+		},
+	} as FileList
+}
+
 describe('file attach component', () => {
+	beforeEach(() => {
+		mockFiles.value = null
+	})
+
 	it('renders attach and reset buttons by default', () => {
 		const wrapper = mount(AFileAttach, {
 			props: { label: 'Attach File' },
@@ -37,5 +66,107 @@ describe('file attach component', () => {
 		})
 		expect(wrapper.find('button').exists()).toBe(false)
 		expect(wrapper.find('.aform_display-value').text()).toBe('No file selected')
+	})
+
+	it('renders display mode with single file', async () => {
+		mockFiles.value = createFileList([new File(['content'], 'test.pdf', { type: 'application/pdf' })])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'display' },
+		})
+
+		await flushPromises()
+
+		expect(wrapper.find('.aform_file-attach-feedback').exists()).toBe(true)
+		expect(wrapper.text()).toContain('1 file')
+		expect(wrapper.text()).toContain('test.pdf')
+	})
+
+	it('renders display mode with multiple files', async () => {
+		mockFiles.value = createFileList([
+			new File(['content1'], 'file1.pdf', { type: 'application/pdf' }),
+			new File(['content2'], 'file2.pdf', { type: 'application/pdf' }),
+		])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'display' },
+		})
+
+		await flushPromises()
+
+		expect(wrapper.find('.aform_file-attach-feedback').exists()).toBe(true)
+		expect(wrapper.text()).toContain('2 files')
+		expect(wrapper.text()).toContain('file1.pdf')
+		expect(wrapper.text()).toContain('file2.pdf')
+	})
+
+	it('renders edit mode with files selected', async () => {
+		mockFiles.value = createFileList([new File(['content'], 'test.pdf', { type: 'application/pdf' })])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'edit' },
+		})
+
+		await flushPromises()
+
+		expect(wrapper.find('.aform_file-attach-feedback').exists()).toBe(true)
+		expect(wrapper.text()).toContain('You have selected:')
+		expect(wrapper.text()).toContain('1 file')
+		expect(wrapper.text()).toContain('test.pdf')
+	})
+
+	it('reset button is enabled when files are selected', async () => {
+		mockFiles.value = createFileList([new File(['content'], 'test.pdf', { type: 'application/pdf' })])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File' },
+		})
+
+		await flushPromises()
+
+		const resetBtn = wrapper.findAll('button')[1]
+		expect(resetBtn.attributes('disabled')).toBeUndefined()
+	})
+
+	it('both buttons are disabled in read mode even when files are selected', async () => {
+		mockFiles.value = createFileList([new File(['content'], 'test.pdf', { type: 'application/pdf' })])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File', mode: 'read' },
+		})
+
+		await flushPromises()
+
+		const buttons = wrapper.findAll('button')
+		expect(buttons[0].attributes()).toHaveProperty('disabled')
+		expect(buttons[1].attributes()).toHaveProperty('disabled')
+	})
+
+	it('clicking attach button calls open function', async () => {
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File' },
+		})
+
+		await flushPromises()
+
+		const attachBtn = wrapper.findAll('button')[0]
+		await attachBtn.trigger('click')
+
+		expect(wrapper.vm).toBeTruthy()
+	})
+
+	it('clicking reset button calls reset function when files exist', async () => {
+		mockFiles.value = createFileList([new File(['content'], 'test.pdf', { type: 'application/pdf' })])
+
+		const wrapper = mount(AFileAttach, {
+			props: { label: 'Attach File' },
+		})
+
+		await flushPromises()
+
+		const resetBtn = wrapper.findAll('button')[1]
+		await resetBtn.trigger('click')
+
+		expect(wrapper.vm).toBeTruthy()
 	})
 })

--- a/aform/tests/nested-form.spec.ts
+++ b/aform/tests/nested-form.spec.ts
@@ -3,7 +3,8 @@ import { describe, it, expect } from 'vitest'
 
 import AForm from '../src/components/AForm.vue'
 import ATextInput from '../src/components/form/ATextInput.vue'
-import type { SchemaTypes } from '../src/types'
+import type { SchemaTypes, DoctypeSchema } from '../src/types'
+import { isDoctypeMany } from '../src/index'
 
 describe('AForm Nested Schema Rendering', () => {
 	const addressSchema: SchemaTypes[] = [
@@ -495,5 +496,86 @@ describe('AForm Nested Schema Rendering', () => {
 		const nestedSections = wrapper.findAll('.aform-nested-section')
 		expect(nestedSections.length).toBe(1)
 		expect(wrapper.vm).toBeTruthy()
+	})
+
+	it('renders ATable component for Doctype field with cardinality: many', async () => {
+		const tableSchema: SchemaTypes[] = [
+			{
+				fieldname: 'name',
+				fieldtype: 'Data',
+				component: 'ATextInput',
+				label: 'Name',
+			},
+			{
+				fieldname: 'items',
+				fieldtype: 'Doctype',
+				options: 'item',
+				label: 'Items',
+				cardinality: 'many',
+				component: 'ATable',
+				columns: [
+					{ name: 'item_name', label: 'Item', fieldtype: 'Data' },
+					{ name: 'qty', label: 'Qty', fieldtype: 'Int' },
+				],
+				rows: [
+					{ item_name: 'Widget', qty: 5 },
+					{ item_name: 'Gadget', qty: 3 },
+				],
+			} as DoctypeSchema,
+		]
+
+		const wrapper = mount(AForm, {
+			props: {
+				schema: tableSchema,
+				data: {
+					name: 'Test Order',
+					items: [
+						{ item_name: 'Widget', qty: 5 },
+						{ item_name: 'Gadget', qty: 3 },
+					],
+				},
+			},
+			global: {
+				components: { ATextInput },
+			},
+		})
+
+		await wrapper.vm.$nextTick()
+		await flushPromises()
+
+		// Should NOT render nested AForm section (no schema property)
+		const nestedSections = wrapper.findAll('.aform-nested-section')
+		expect(nestedSections.length).toBe(0)
+
+		// Should render a dynamic component (ATable) instead
+		const dynamicComponents = wrapper.findAllComponents({ name: 'ATable' })
+		// ATable may not be registered in test, but the component :is binding
+		// should still attempt to render it — verify no nested form was created
+		expect(nestedSections.length).toBe(0)
+	})
+
+	it('isDoctypeMany type guard correctly narrows DoctypeSchema', () => {
+		const oneField: DoctypeSchema = {
+			fieldname: 'address',
+			fieldtype: 'Doctype',
+			options: 'address',
+			schema: [],
+		}
+
+		const manyField: DoctypeSchema = {
+			fieldname: 'items',
+			fieldtype: 'Doctype',
+			options: 'item',
+			cardinality: 'many',
+			columns: [],
+		}
+
+		expect(isDoctypeMany(oneField)).toBe(false)
+		expect(isDoctypeMany(manyField)).toBe(true)
+
+		// Type narrowing should expose columns on manyField
+		if (isDoctypeMany(manyField)) {
+			expect(manyField.columns).toBeDefined()
+		}
 	})
 })

--- a/common/changes/@stonecrop/aform/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/aform/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "add 1:1 and 1:many doctype schema support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/desktop/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/desktop/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/desktop",
+      "comment": "add 1:1 and 1:many doctype schema support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/desktop"
+}

--- a/common/changes/@stonecrop/graphql-middleware/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/graphql-middleware/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-middleware",
+      "comment": "add 1:1 and 1:many doctype schema support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-middleware"
+}

--- a/common/changes/@stonecrop/nuxt/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/nuxt/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/nuxt",
+      "comment": "update playground to show doctype cardinality",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/nuxt"
+}

--- a/common/changes/@stonecrop/schema/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/schema/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/schema",
+      "comment": "add 1:1 and 1:many doctype schema support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/schema"
+}

--- a/common/changes/@stonecrop/stonecrop/fix-doctype-cardinality_2026-03-23-09-23.json
+++ b/common/changes/@stonecrop/stonecrop/fix-doctype-cardinality_2026-03-23-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "add 1:1 and 1:many doctype schema support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/reviews/api/aform.api.md
+++ b/common/reviews/api/aform.api.md
@@ -62,12 +62,28 @@ export type ComponentProps = {
 };
 
 // @public
-export type DoctypeSchema = BaseSchema & {
+export type DoctypeManySchema = BaseSchema & {
     fieldtype: 'Doctype';
     options: string;
     label?: string;
+    cardinality: 'many';
+    columns?: TableColumn[];
+    config?: TableConfig;
+    rows?: TableRow[];
+    component?: string;
+};
+
+// @public
+export type DoctypeOneSchema = BaseSchema & {
+    fieldtype: 'Doctype';
+    options: string;
+    label?: string;
+    cardinality?: 'one';
     schema?: SchemaTypes[];
 };
+
+// @public
+export type DoctypeSchema = DoctypeOneSchema | DoctypeManySchema;
 
 // @public
 export type FieldsetSchema = BaseSchema & {
@@ -93,20 +109,13 @@ export type FormSchema = BaseSchema & {
 // @public
 export function install(app: App): void;
 
+// @public
+export function isDoctypeMany(field: DoctypeSchema): field is DoctypeManySchema;
+
 export { Login }
 
 // @public
-export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema | TableDoctypeSchema;
-
-// @public
-export type TableDoctypeSchema = BaseSchema & {
-    fieldtype: 'Table';
-    options: string;
-    label?: string;
-    columns?: TableColumn[];
-    config?: TableConfig;
-    rows?: TableRow[];
-};
+export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema;
 
 // @public
 export type TableSchema = BaseSchema & {

--- a/common/reviews/api/schema.api.md
+++ b/common/reviews/api/schema.api.md
@@ -118,6 +118,10 @@ const DoctypeMeta: z.ZodObject<{
         value: z.ZodOptional<z.ZodUnknown>;
         default: z.ZodOptional<z.ZodUnknown>;
         options: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>, z.ZodRecord<z.ZodString, z.ZodUnknown>]>>;
+        cardinality: z.ZodOptional<z.ZodEnum<{
+            one: "one";
+            many: "many";
+        }>>;
         mask: z.ZodOptional<z.ZodString>;
         validation: z.ZodOptional<z.ZodObject<{
             errorMessage: z.ZodString;
@@ -191,6 +195,10 @@ const FieldMeta: z.ZodObject<{
     value: z.ZodOptional<z.ZodUnknown>;
     default: z.ZodOptional<z.ZodUnknown>;
     options: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>, z.ZodRecord<z.ZodString, z.ZodUnknown>]>>;
+    cardinality: z.ZodOptional<z.ZodEnum<{
+        one: "one";
+        many: "many";
+    }>>;
     mask: z.ZodOptional<z.ZodString>;
     validation: z.ZodOptional<z.ZodObject<{
         errorMessage: z.ZodString;

--- a/common/reviews/api/stonecrop.api.md
+++ b/common/reviews/api/stonecrop.api.md
@@ -259,7 +259,7 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
     formData: Ref<Record<string, any>>;
     resolvedSchema: Ref<SchemaTypes[]>;
     loadNestedData: (parentPath: string, childDoctype: Doctype, recordId?: string) => Record<string, any>;
-    saveRecursive: (doctype: Doctype, recordId: string) => Promise<Record<string, any>>;
+    collectRecordPayload: (doctype: Doctype, recordId: string) => Record<string, any>;
     createNestedContext: (basePath: string, childDoctype: Doctype) => {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;

--- a/desktop/src/components/Desktop.vue
+++ b/desktop/src/components/Desktop.vue
@@ -575,8 +575,9 @@ const getRecordFormSchema = (): SchemaTypes[] => {
 			return []
 		}
 
-		// Data is provided via v-model:data="currentViewData" — no need to spread values into schema
-		return 'toArray' in doctype.schema ? doctype.schema.toArray() : doctype.schema
+		// Convert schema to array and resolve Doctype fields (both cardinality: 'one' and 'many')
+		const schemaArray = 'toArray' in doctype.schema ? doctype.schema.toArray() : doctype.schema
+		return registry.resolveSchema(schemaArray)
 	} catch {
 		return []
 	}

--- a/docs/guides/hst-patterns.md
+++ b/docs/guides/hst-patterns.md
@@ -1,0 +1,138 @@
+---
+title: HST Data Patterns
+description: Common patterns for working with the Hierarchical State Tree (HST) in Stonecrop
+---
+
+# HST Data Patterns
+
+The Hierarchical State Tree (HST) stores form data as flat paths, but APIs typically expect nested objects. This guide covers common patterns for working with HST data.
+
+---
+
+## HST Path Structure
+
+HST stores values at dot-separated paths:
+
+```
+customer.123.name = "John Doe"
+customer.123.address.street = "123 Main St"
+customer.123.address.city = "Portland"
+customer.123.address.phones = [{ number: "555-1234" }, { number: "555-5678" }]
+```
+
+---
+
+## Collecting Data for API Submission
+
+Use `collectRecordPayload` to gather all nested data from HST into a single object ready for API submission.
+
+### When to Use
+
+Call `collectRecordPayload` in your doctype's **save action** defined in the workflow. This keeps the framework opinion-free about persistence while providing the infrastructure to assemble nested records.
+
+### Example: Save Action in Workflow
+
+```typescript
+import { Doctype, useStonecrop } from '@stonecrop/stonecrop'
+import { List, Map } from 'immutable'
+import { apiClient } from './api-client'
+
+const customerDoctype = new Doctype(
+  'Customer',
+  List([
+    { fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' },
+    { fieldname: 'address', fieldtype: 'Doctype', options: 'address' },
+  ]),
+  {
+    id: 'customer',
+    initial: 'draft',
+    states: {
+      draft: {
+        on: {
+          submit: { target: 'submitted', actions: ['saveRecord'] }
+        }
+      },
+      submitted: { type: 'final' }
+    }
+  },
+  Map({
+    submit: ['validateData', 'saveRecord'],
+  })
+)
+
+// In your action handler:
+async function saveRecord(context) {
+  const { collectRecordPayload } = useStonecrop({
+    registry,
+    doctype: customerDoctype,
+    recordId: context.recordId
+  })
+
+  // Collect all nested data into a single payload
+  const payload = collectRecordPayload(customerDoctype, context.recordId)
+
+  // Send to your API
+  await apiClient.save('/customers', payload)
+}
+```
+
+---
+
+## How It Works
+
+Given a schema with nested Doctype fields:
+
+```typescript
+[
+  { fieldname: 'name', fieldtype: 'Data' },
+  { fieldname: 'address', fieldtype: 'Doctype', options: 'address' },  // 1:1
+  { fieldname: 'orders', fieldtype: 'Doctype', options: 'order', cardinality: 'many' },  // 1:many
+]
+```
+
+With HST containing:
+
+```
+customer.123.name = "Acme Corp"
+customer.123.address.street = "123 Main St"
+customer.123.address.city = "Portland"
+customer.123.orders = [{ total: 100 }, { total: 250 }]
+```
+
+`collectRecordPayload` returns:
+
+```json
+{
+  "name": "Acme Corp",
+  "address": {
+    "street": "123 Main St",
+    "city": "Portland"
+  },
+  "orders": [
+    { "total": 100 },
+    { "total": 250 }
+  ]
+}
+```
+
+---
+
+## Modifying the Payload
+
+Since `collectRecordPayload` returns a plain object, you can modify it before sending:
+
+```typescript
+const payload = collectRecordPayload(doctype, recordId)
+
+// Add metadata
+payload._version = 2
+payload._savedAt = new Date().toISOString()
+
+// Remove sensitive fields
+delete payload.internalNotes
+
+// Transform for legacy API
+payload.address = `${payload.address.street}, ${payload.address.city}`
+
+await apiClient.save(payload)
+```

--- a/docs/reference/aform.md
+++ b/docs/reference/aform.md
@@ -115,6 +115,22 @@ declare function install(app: App): void;
 |-----------|------|-------------|
 | app | `App` | Vue app instance |
 
+### isDoctypeMany
+
+Type guard that checks whether a Doctype schema field has `cardinality: 'many'`
+
+**Signature:**
+
+```typescript
+export declare function isDoctypeMany(field: DoctypeSchema): field is DoctypeManySchema;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| field | `DoctypeSchema` | A DoctypeSchema field to check |
+
 ## Type Aliases
 
 ### BaseSchema
@@ -152,19 +168,49 @@ export type ComponentProps = {
 };
 ```
 
-### DoctypeSchema
+### DoctypeManySchema
 
-Schema structure for defining nested doctype fields inside AForm
+Schema structure for a 1:many child table field inside AForm
 
 **Definition:**
 
 ```typescript
-export type DoctypeSchema = BaseSchema & {
+export type DoctypeManySchema = BaseSchema & {
     fieldtype: 'Doctype';
     options: string;
     label?: string;
+    cardinality: 'many';
+    columns?: TableColumn[];
+    config?: TableConfig;
+    rows?: TableRow[];
+    component?: string;
+};
+```
+
+### DoctypeOneSchema
+
+Schema structure for a 1:1 nested doctype field inside AForm
+
+**Definition:**
+
+```typescript
+export type DoctypeOneSchema = BaseSchema & {
+    fieldtype: 'Doctype';
+    options: string;
+    label?: string;
+    cardinality?: 'one';
     schema?: SchemaTypes[];
 };
+```
+
+### DoctypeSchema
+
+Discriminated union for Doctype fields — either 1:1 nested form or 1:many child table
+
+**Definition:**
+
+```typescript
+export type DoctypeSchema = DoctypeOneSchema | DoctypeManySchema;
 ```
 
 ### FieldsetSchema
@@ -216,24 +262,7 @@ Superset of all schema types for AForm
 **Definition:**
 
 ```typescript
-export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema | TableDoctypeSchema;
-```
-
-### TableDoctypeSchema
-
-Schema structure for defining 1:many child table fields inside AForm
-
-**Definition:**
-
-```typescript
-export type TableDoctypeSchema = BaseSchema & {
-    fieldtype: 'Table';
-    options: string;
-    label?: string;
-    columns?: TableColumn[];
-    config?: TableConfig;
-    rows?: TableRow[];
-};
+export type SchemaTypes = FormSchema | TableSchema | FieldsetSchema | DoctypeSchema;
 ```
 
 ### TableSchema

--- a/docs/reference/stonecrop.md
+++ b/docs/reference/stonecrop.md
@@ -1007,7 +1007,7 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
     formData: Ref<Record<string, any>>;
     resolvedSchema: Ref<SchemaTypes[]>;
     loadNestedData: (parentPath: string, childDoctype: Doctype, recordId?: string) => Record<string, any>;
-    saveRecursive: (doctype: Doctype, recordId: string) => Promise<Record<string, any>>;
+    collectRecordPayload: (doctype: Doctype, recordId: string) => Record<string, any>;
     createNestedContext: (basePath: string, childDoctype: Doctype) => {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;

--- a/docs/reference/stonecrop.md
+++ b/docs/reference/stonecrop.md
@@ -1477,7 +1477,7 @@ initializeRecord(schema: SchemaTypes[]): Record<string, any>
 
 #### resolveSchema
 
-Resolve nested Doctype and Table fields in a schema by embedding child schemas inline.
+Resolve nested Doctype fields in a schema by embedding child schemas inline.
 
 ```typescript
 resolveSchema(schema: SchemaTypes[], visited: Set<string>): SchemaTypes[]

--- a/examples/aform/assets/customer_with_addresses_schema.json
+++ b/examples/aform/assets/customer_with_addresses_schema.json
@@ -23,7 +23,8 @@
 		},
 		{
 			"fieldname": "addresses",
-			"fieldtype": "Table",
+			"fieldtype": "Doctype",
+			"cardinality": "many",
 			"options": "address",
 			"label": "Addresses"
 		}

--- a/examples/aform/nested.story.vue
+++ b/examples/aform/nested.story.vue
@@ -356,9 +356,9 @@ const HSTDemo = defineComponent({
  * Variant 4 — 1:Many (Address List)
  *
  * A parent Customer form with scalar fields rendered normally, and a child
- * `addresses` array rendered as an ATable. The schema uses `fieldtype: 'Table'`
- * with `options: 'address'` — resolveSchema auto-derives columns from the
- * Address doctype's fields and sets the component to ATable.
+ * `addresses` array rendered as an ATable. The schema uses `fieldtype: 'Doctype'`
+ * with `cardinality: 'many'` and `options: 'address'` — resolveSchema auto-derives
+ * columns from the Address doctype's fields and sets the component to ATable.
  */
 const AddressListDemo = defineComponent({
 	name: 'AddressListDemo',
@@ -385,7 +385,7 @@ const AddressListDemo = defineComponent({
 			h(
 				'p',
 				{ class: 'info-text' },
-				"The \"addresses\" field uses fieldtype: 'Table' with options: 'address'. " +
+				"The \"addresses\" field uses fieldtype: 'Doctype' with cardinality: 'many' and options: 'address'. " +
 					'resolveSchema() auto-derives columns from the Address doctype and sets component to ATable.'
 			),
 			h(AForm, {
@@ -659,22 +659,22 @@ const AddressListDemo = defineComponent({
 <docs lang="md">
 # Nested Schema Support
 
-Demonstrates how `Registry.resolveSchema()` embeds child schemas on `Doctype` fields (1:1)
-and auto-derives table columns for `Table` fields (1:many). AForm renders both patterns
-without knowing anything about the Registry.
+Demonstrates how `Registry.resolveSchema()` embeds child schemas on `Doctype` fields.
+For 1:1 nested forms, it attaches `schema` arrays; for 1:many tables (`cardinality: 'many'`),
+it auto-derives table columns. AForm renders both patterns without knowing anything about the Registry.
 
 ## How It Works
 
-### 1:1 (Doctype fields)
+### 1:1 (Doctype fields, default cardinality)
 
 1. Register doctypes in the Registry
 2. Call `registry.resolveSchema(schema)` — attaches `schema` arrays to Doctype fields
 3. Pass the resolved schema to `<AForm>` — it checks `'schema' in field` and recurses
 
-### 1:Many (Table fields)
+### 1:Many (Doctype fields with cardinality: 'many')
 
 1. Register parent and child doctypes in the Registry
-2. Call `registry.resolveSchema(schema)` — for `fieldtype: 'Table'` fields, auto-derives
+2. Call `registry.resolveSchema(schema)` — for `fieldtype: 'Doctype', cardinality: 'many'` fields, auto-derives
    `columns` from the child doctype's schema, sets `component: 'ATable'` and `config: { view: 'list' }`
 3. Pass the resolved schema to `<AForm>` — the child array data at `data[fieldname]`
    flows into ATable's rows via the `componentProps` fallback
@@ -704,11 +704,11 @@ columns, config, or component by specifying them explicitly on the schema field.
 ## Usage
 
 ```typescript
-// 1:1 nesting
+// 1:1 nesting (default cardinality)
 const resolved = registry.resolveSchema(customerSchema)
 // resolved[3].schema === [street, city, state, zip_code]
 
-// 1:many table
+// 1:many table (cardinality: 'many')
 const resolved = registry.resolveSchema(customerWithAddressesSchema)
 // resolved[3].columns === [{ name: 'street', ... }, { name: 'city', ... }, ...]
 // resolved[3].component === 'ATable'

--- a/graphql_middleware/src/registry/actions.ts
+++ b/graphql_middleware/src/registry/actions.ts
@@ -1,4 +1,4 @@
-import type { DoctypeMeta } from '@stonecrop/schema'
+import type { DoctypeMeta, FieldMeta } from '@stonecrop/schema'
 import type { ActionHandler, ActionContext } from '../types'
 
 const handlerRegistry: Map<string, ActionHandler> = new Map()
@@ -77,7 +77,7 @@ const validateFieldTypes: ActionHandler = async (args, context) => {
 		const value = record[field.fieldname]
 		if (value === undefined || value === null) continue
 
-		const error = validateFieldValue(field.fieldname, value, field.fieldtype)
+		const error = validateFieldValue(field, value)
 		if (error) errors.push(error)
 	}
 
@@ -91,7 +91,9 @@ const validateFieldTypes: ActionHandler = async (args, context) => {
 /**
  * Validate a single field value against its expected type
  */
-function validateFieldValue(fieldname: string, value: unknown, fieldtype: string): string | null {
+function validateFieldValue(field: FieldMeta, value: unknown): string | null {
+	const { fieldname, fieldtype, cardinality } = field
+
 	switch (fieldtype) {
 		case 'Int':
 			if (typeof value !== 'number' || !Number.isInteger(value)) {
@@ -137,9 +139,15 @@ function validateFieldValue(fieldname: string, value: unknown, fieldtype: string
 			}
 			break
 
-		case 'Table':
-			if (!Array.isArray(value)) {
-				return `${fieldname}: expected array, got ${typeof value}`
+		case 'Doctype':
+			if (cardinality === 'many') {
+				if (!Array.isArray(value)) {
+					return `${fieldname}: expected array, got ${typeof value}`
+				}
+			} else {
+				if (typeof value !== 'object' || Array.isArray(value)) {
+					return `${fieldname}: expected object, got ${typeof value}`
+				}
 			}
 			break
 	}

--- a/graphql_middleware/tests/registry.test.ts
+++ b/graphql_middleware/tests/registry.test.ts
@@ -196,7 +196,8 @@ describe('validateFieldTypes handler', () => {
 			{ fieldname: 'meeting_time', fieldtype: 'Time', label: 'Time' },
 			{ fieldname: 'created_at', fieldtype: 'Datetime', label: 'Datetime' },
 			{ fieldname: 'meta', fieldtype: 'JSON', label: 'Meta' },
-			{ fieldname: 'items', fieldtype: 'Table', label: 'Items' },
+			{ fieldname: 'items', fieldtype: 'Doctype', cardinality: 'many', label: 'Items', options: 'Item' },
+			{ fieldname: 'parent', fieldtype: 'Doctype', label: 'Parent', options: 'Parent' },
 		],
 	}
 
@@ -217,6 +218,7 @@ describe('validateFieldTypes handler', () => {
 			created_at: '2024-01-01T10:00:00Z',
 			meta: { key: 'value' },
 			items: [{ row: 1 }],
+			parent: { name: 'parent' },
 		}
 		const result = await builtinHandlers.validateFieldTypes([record], makeContext(typedDoctype))
 		expect(result).toEqual({ valid: true })
@@ -282,10 +284,22 @@ describe('validateFieldTypes handler', () => {
 		).rejects.toThrow('expected object')
 	})
 
-	it('throws for a non-array Table value', async () => {
+	it('throws for a non-array Doctype value with cardinality many', async () => {
 		await expect(
 			builtinHandlers.validateFieldTypes([{ items: 'not-an-array' }], makeContext(typedDoctype))
 		).rejects.toThrow('expected array')
+	})
+
+	it('throws for a non-object Doctype value with cardinality one (default)', async () => {
+		await expect(
+			builtinHandlers.validateFieldTypes([{ parent: 'not-an-object' }], makeContext(typedDoctype))
+		).rejects.toThrow('expected object')
+	})
+
+	it('throws for an array Doctype value with cardinality one (default)', async () => {
+		await expect(
+			builtinHandlers.validateFieldTypes([{ parent: [{ name: 'parent' }] }], makeContext(typedDoctype))
+		).rejects.toThrow('expected object')
 	})
 
 	it('accepts a Date instance for Date field', async () => {

--- a/nuxt/playground/utils/schema.ts
+++ b/nuxt/playground/utils/schema.ts
@@ -11,8 +11,7 @@ const fieldtypeToComponent: Record<string, string> = {
 	Datetime: 'ADate',
 	Select: 'ADropdown',
 	Link: 'AComboBox',
-	Table: 'ATable',
-	Doctype: 'ATable', // Doctype renders as a table of related records
+	Doctype: 'AForm', // Doctype renders as nested form (1:1) or table (1:many) based on cardinality
 	JSON: 'ATextInput', // Default to text input for JSON
 	// Add more mappings as needed
 }
@@ -28,26 +27,22 @@ export function hydrateSchema(schema: any[]): any[] {
 			component,
 		}
 
-		// Special handling for Table fieldtype
-		if (field.fieldtype === 'Table' && field.options && Array.isArray(field.options)) {
-			// Hydrate nested schema for table columns
-			hydratedField.columns = field.options.map((col: any) => ({
-				name: col.fieldname,
-				label: col.label,
-				fieldtype: col.fieldtype || 'Data',
-			}))
-			// Initialize empty rows array
-			hydratedField.rows = []
-		}
-
-		// Special handling for Doctype fieldtype (related records displayed as table)
+		// Special handling for Doctype fieldtype
 		if (field.fieldtype === 'Doctype') {
-			// Use columns if provided in the schema
-			if (field.columns && Array.isArray(field.columns)) {
-				hydratedField.columns = field.columns
+			// For cardinality: 'many', derive columns and use ATable
+			if (field.cardinality === 'many') {
+				// Use columns if provided in the schema
+				if (field.columns && Array.isArray(field.columns)) {
+					hydratedField.columns = field.columns
+				}
+				hydratedField.component = 'ATable'
+				// Will be populated from data via AForm's componentProps
+				hydratedField.rows = []
 			}
-			// Will be populated from data via AForm's componentProps
-			hydratedField.rows = []
+			// For cardinality: 'one' (default), embed schema for nested AForm
+			if (field.schema && Array.isArray(field.schema)) {
+				hydratedField.schema = field.schema
+			}
 		}
 
 		return hydratedField

--- a/schema/src/converter/heuristics.ts
+++ b/schema/src/converter/heuristics.ts
@@ -280,6 +280,7 @@ export function classifyFieldType(
 			base.component = 'ATable'
 			base.fieldtype = 'Doctype'
 			base.options = toSlug(connectionNodeTypeName)
+			base.cardinality = 'many'
 			return base
 		}
 
@@ -288,6 +289,7 @@ export function classifyFieldType(
 			base.component = 'ATable'
 			base.fieldtype = 'Doctype'
 			base.options = toSlug(namedType.name)
+			base.cardinality = 'many'
 			return base
 		}
 

--- a/schema/src/field.ts
+++ b/schema/src/field.ts
@@ -119,6 +119,13 @@ export const FieldMeta = z
 		options: FieldOptions.optional(),
 
 		/**
+		 * Cardinality for Doctype fields:
+		 * - 'one': 1:1 nested form (default)
+		 * - 'many': 1:many child table
+		 */
+		cardinality: z.enum(['one', 'many']).optional(),
+
+		/**
 		 * Input mask pattern. Accepts either a plain mask string or a stringified
 		 * arrow function that receives `locale` and returns a mask string.
 		 *

--- a/schema/src/fieldtype.ts
+++ b/schema/src/fieldtype.ts
@@ -21,7 +21,7 @@ export const StonecropFieldType = z
 		'JSON', // JSON data
 		'Code', // Code/source (with syntax highlighting)
 		'Link', // Reference to another doctype
-		'Doctype', // Child doctype (renders as table)
+		'Doctype', // Child doctype (1:1 nested form or 1:many table via cardinality)
 		'Attach', // File attachment
 		'Currency', // Currency value
 		'Quantity', // Quantity with unit
@@ -85,7 +85,7 @@ export const TYPE_MAP: Record<StonecropFieldType, FieldTemplate> = {
 
 	// Relational
 	Link: { component: 'ALink', fieldtype: 'Link' },
-	Doctype: { component: 'ATable', fieldtype: 'Doctype' },
+	Doctype: { component: 'AForm', fieldtype: 'Doctype' },
 
 	// Files
 	Attach: { component: 'AFileAttach', fieldtype: 'Attach' },

--- a/schema/tests/converter.spec.ts
+++ b/schema/tests/converter.spec.ts
@@ -345,6 +345,7 @@ describe('classifyFieldType', () => {
 		expect(field.fieldtype).toBe('Doctype')
 		expect(field.component).toBe('ATable')
 		expect(field.options).toBe('comment')
+		expect(field.cardinality).toBe('many')
 	})
 
 	it('should include unmapped meta when requested', () => {
@@ -478,6 +479,7 @@ describe('convertGraphQLSchema', () => {
 			const commentsField = post.fields.find(f => f.fieldname === 'comments')!
 			expect(commentsField.fieldtype).toBe('Doctype')
 			expect(commentsField.options).toBe('comment')
+			expect(commentsField.cardinality).toBe('many')
 		})
 	})
 
@@ -650,6 +652,7 @@ describe('convertGraphQLSchema', () => {
 			const itemsField = order.fields.find(f => f.fieldname === 'items')!
 			expect(itemsField.fieldtype).toBe('Doctype')
 			expect(itemsField.options).toBe('order-item')
+			expect(itemsField.cardinality).toBe('many')
 		})
 	})
 

--- a/stonecrop/api.md
+++ b/stonecrop/api.md
@@ -1002,7 +1002,7 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
     formData: Ref<Record<string, any>>;
     resolvedSchema: Ref<SchemaTypes[]>;
     loadNestedData: (parentPath: string, childDoctype: Doctype, recordId?: string) => Record<string, any>;
-    saveRecursive: (doctype: Doctype, recordId: string) => Promise<Record<string, any>>;
+    collectRecordPayload: (doctype: Doctype, recordId: string) => Record<string, any>;
     createNestedContext: (basePath: string, childDoctype: Doctype) => {
         provideHSTPath: (fieldname: string) => string;
         handleHSTChange: (changeData: HSTChangeData) => void;

--- a/stonecrop/api.md
+++ b/stonecrop/api.md
@@ -1472,7 +1472,7 @@ initializeRecord(schema: SchemaTypes[]): Record<string, any>
 
 #### resolveSchema
 
-Resolve nested Doctype and Table fields in a schema by embedding child schemas inline.
+Resolve nested Doctype fields in a schema by embedding child schemas inline.
 
 ```typescript
 resolveSchema(schema: SchemaTypes[], visited: Set<string>): SchemaTypes[]

--- a/stonecrop/docs/schema/nested-schemas.md
+++ b/stonecrop/docs/schema/nested-schemas.md
@@ -415,12 +415,13 @@ This provides the best developer experience when using full Stonecrop integratio
 
 ## Nested Table Schemas
 
-For **1:many relationships** (collections of records), use ATable with a `Table` fieldtype instead:
+For **1:many relationships** (collections of records), use a `Doctype` fieldtype with `cardinality: 'many'`:
 
 ```json
 {
   "fieldname": "line_items",
-  "fieldtype": "Table",
+  "fieldtype": "Doctype",
+  "cardinality": "many",
   "options": "sales_order_item",
   "label": "Line Items"
 }

--- a/stonecrop/src/composables/stonecrop.ts
+++ b/stonecrop/src/composables/stonecrop.ts
@@ -1,4 +1,11 @@
-import { type SchemaTypes, type DoctypeSchema, type DoctypeOneSchema, isDoctypeMany } from '@stonecrop/aform'
+import {
+	type DoctypeManySchema,
+	type DoctypeOneSchema,
+	type DoctypeSchema,
+	type FormSchema,
+	type SchemaTypes,
+	isDoctypeMany,
+} from '@stonecrop/aform'
 import { storeToRefs } from 'pinia'
 import { inject, onMounted, Ref, ref, watch, provide, computed, type ComputedRef } from 'vue'
 
@@ -524,6 +531,8 @@ export function useStonecrop(options?: {
 				: Array.from(doctype.schema)
 			: []
 		const resolved = registry ? registry.resolveSchema(schemaArray) : schemaArray
+
+		// 1:1 nested Doctype fields (cardinality: 'one' or undefined)
 		const doctypeFields = resolved.filter(
 			field =>
 				'fieldtype' in field &&
@@ -539,6 +548,21 @@ export function useStonecrop(options?: {
 			const fieldPath = `${recordPath}.${doctypeField.fieldname}`
 			const nestedData = collectNestedData(doctypeField.schema!, fieldPath, hstStore.value)
 			payload[doctypeField.fieldname] = nestedData
+		}
+
+		// 1:many child tables (cardinality: 'many')
+		const doctypeManyFields = resolved.filter(
+			field => 'fieldtype' in field && field.fieldtype === 'Doctype' && isDoctypeMany(field as DoctypeSchema)
+		)
+
+		// Read array data from HST for cardinality: 'many' fields
+		for (const field of doctypeManyFields) {
+			const doctypeField = field as DoctypeManySchema
+			const fieldPath = `${recordPath}.${doctypeField.fieldname}`
+			const arrayData = hstStore.value.get(fieldPath)
+			if (Array.isArray(arrayData)) {
+				payload[doctypeField.fieldname] = arrayData
+			}
 		}
 
 		return payload
@@ -661,12 +685,21 @@ function initializeNewRecord(doctype: Doctype): Record<string, any> {
 			case 'Float':
 				initialData[field.fieldname] = 0
 				break
-			case 'Table':
-				initialData[field.fieldname] = []
-				break
 			case 'JSON':
 				initialData[field.fieldname] = {}
 				break
+			case 'Doctype': {
+				// Check cardinality to determine initial value
+				const cardinality = 'cardinality' in field ? field.cardinality : undefined
+				if (cardinality === 'many') {
+					// 1:many child table - initialize as empty array
+					initialData[field.fieldname] = []
+				} else {
+					// 1:1 nested form - initialize as empty object
+					initialData[field.fieldname] = {}
+				}
+				break
+			}
 			default:
 				initialData[field.fieldname] = null
 		}
@@ -749,6 +782,20 @@ function collectNestedData(resolvedSchema: SchemaTypes[], basePath: string, hstS
 		const fieldPath = `${basePath}.${doctypeField.fieldname}`
 		const nestedData = collectNestedData(doctypeField.schema!, fieldPath, hstStore)
 		payload[doctypeField.fieldname] = nestedData
+	}
+
+	// Also collect array data for cardinality: 'many' fields
+	const doctypeManyFields = resolvedSchema.filter(
+		field => 'fieldtype' in field && field.fieldtype === 'Doctype' && isDoctypeMany(field as DoctypeSchema)
+	)
+
+	for (const field of doctypeManyFields) {
+		const doctypeField = field as DoctypeManySchema
+		const fieldPath = `${basePath}.${doctypeField.fieldname}`
+		const arrayData = hstStore.get(fieldPath)
+		if (Array.isArray(arrayData)) {
+			payload[doctypeField.fieldname] = arrayData
+		}
 	}
 
 	return payload

--- a/stonecrop/src/composables/stonecrop.ts
+++ b/stonecrop/src/composables/stonecrop.ts
@@ -2,7 +2,6 @@ import {
 	type DoctypeManySchema,
 	type DoctypeOneSchema,
 	type DoctypeSchema,
-	type FormSchema,
 	type SchemaTypes,
 	isDoctypeMany,
 } from '@stonecrop/aform'
@@ -73,7 +72,7 @@ export type HSTStonecropReturn = BaseStonecropReturn & {
 	formData: Ref<Record<string, any>>
 	resolvedSchema: Ref<SchemaTypes[]>
 	loadNestedData: (parentPath: string, childDoctype: Doctype, recordId?: string) => Record<string, any>
-	saveRecursive: (doctype: Doctype, recordId: string) => Promise<Record<string, any>>
+	collectRecordPayload: (doctype: Doctype, recordId: string) => Record<string, any>
 	createNestedContext: (
 		basePath: string,
 		childDoctype: Doctype
@@ -508,12 +507,12 @@ export function useStonecrop(options?: {
 	}
 
 	/**
-	 * Recursively save a record with all nested doctype fields
+	 * Collect a record payload with all nested doctype fields from HST
 	 * @param doctype - The doctype metadata
-	 * @param recordId - The record ID to save
-	 * @returns The complete save payload
+	 * @param recordId - The record ID to collect
+	 * @returns The complete record payload ready for API submission
 	 */
-	const saveRecursive = (doctype: Doctype, recordId: string): Record<string, any> => {
+	const collectRecordPayload = (doctype: Doctype, recordId: string): Record<string, any> => {
 		if (!hstStore.value || !stonecrop.value) {
 			throw new Error('HST store not initialized')
 		}
@@ -628,7 +627,7 @@ export function useStonecrop(options?: {
 			formData,
 			resolvedSchema,
 			loadNestedData,
-			saveRecursive,
+			collectRecordPayload,
 			createNestedContext,
 			isLoading,
 			error,
@@ -645,7 +644,7 @@ export function useStonecrop(options?: {
 			formData,
 			resolvedSchema,
 			loadNestedData,
-			saveRecursive,
+			collectRecordPayload,
 			createNestedContext,
 			isLoading,
 			error,

--- a/stonecrop/src/composables/stonecrop.ts
+++ b/stonecrop/src/composables/stonecrop.ts
@@ -1,13 +1,13 @@
-import { inject, onMounted, Ref, ref, watch, provide, computed, ComputedRef } from 'vue'
+import { type SchemaTypes, type DoctypeSchema, type DoctypeOneSchema, isDoctypeMany } from '@stonecrop/aform'
+import { storeToRefs } from 'pinia'
+import { inject, onMounted, Ref, ref, watch, provide, computed, type ComputedRef } from 'vue'
 
 import Registry from '../registry'
 import { Stonecrop } from '../stonecrop'
 import Doctype from '../doctype'
 import type { HSTNode } from '../stores/hst'
-import { RouteContext } from '../types/registry'
-import { storeToRefs } from 'pinia'
+import type { RouteContext } from '../types/registry'
 import type { HSTOperation, OperationLogConfig, OperationLogSnapshot } from '../types/operation-log'
-import { SchemaTypes, DoctypeSchema } from '@stonecrop/aform'
 
 /**
  * Operation Log API - nested object containing all operation log functionality
@@ -525,12 +525,17 @@ export function useStonecrop(options?: {
 			: []
 		const resolved = registry ? registry.resolveSchema(schemaArray) : schemaArray
 		const doctypeFields = resolved.filter(
-			field => 'fieldtype' in field && field.fieldtype === 'Doctype' && 'schema' in field && Array.isArray(field.schema)
+			field =>
+				'fieldtype' in field &&
+				field.fieldtype === 'Doctype' &&
+				!isDoctypeMany(field as DoctypeSchema) &&
+				'schema' in field &&
+				Array.isArray(field.schema)
 		)
 
 		// Recursively collect nested data from HST using resolved schemas
 		for (const field of doctypeFields) {
-			const doctypeField = field as DoctypeSchema
+			const doctypeField = field as DoctypeOneSchema
 			const fieldPath = `${recordPath}.${doctypeField.fieldname}`
 			const nestedData = collectNestedData(doctypeField.schema!, fieldPath, hstStore.value)
 			payload[doctypeField.fieldname] = nestedData
@@ -728,14 +733,19 @@ function collectNestedData(resolvedSchema: SchemaTypes[], basePath: string, hstS
 	const data = hstStore.get(basePath) || {}
 	const payload: Record<string, any> = { ...data }
 
-	// Find Doctype fields that have resolved child schemas
+	// Find Doctype fields that have resolved child schemas (1:1 only, not cardinality: 'many')
 	const doctypeFields = resolvedSchema.filter(
-		field => 'fieldtype' in field && field.fieldtype === 'Doctype' && 'schema' in field && Array.isArray(field.schema)
+		field =>
+			'fieldtype' in field &&
+			field.fieldtype === 'Doctype' &&
+			!isDoctypeMany(field as DoctypeSchema) &&
+			'schema' in field &&
+			Array.isArray(field.schema)
 	)
 
 	// Recursively collect nested data
 	for (const field of doctypeFields) {
-		const doctypeField = field as DoctypeSchema
+		const doctypeField = field as DoctypeOneSchema
 		const fieldPath = `${basePath}.${doctypeField.fieldname}`
 		const nestedData = collectNestedData(doctypeField.schema!, fieldPath, hstStore)
 		payload[doctypeField.fieldname] = nestedData

--- a/stonecrop/src/field-triggers.ts
+++ b/stonecrop/src/field-triggers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-new-func, no-eval */
 import type { Map as ImmutableMap } from 'immutable'
 import { useOperationLogStore } from './stores/operation-log'
 import type {
@@ -101,11 +100,11 @@ export class FieldTriggerEngine {
 		const transitionMap = new Map<string, string[]>()
 
 		// Convert from different Map types to regular Map
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if (typeof (actions as any).entrySeq === 'function') {
+		// Check for Immutable.js Map first (has entrySeq method)
+		const immutableActions = actions as ImmutableMap<string, string[]>
+		if (typeof immutableActions.entrySeq === 'function') {
 			// Immutable Map
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			;(actions as any).entrySeq().forEach(([key, value]: [string, string[]]) => {
+			immutableActions.entrySeq().forEach(([key, value]: [string, string[]]) => {
 				this.categorizeAction(key, value, actionMap, transitionMap)
 			})
 		} else if (actions instanceof Map) {
@@ -506,7 +505,7 @@ export class FieldTriggerEngine {
 				})
 				.catch(error => {
 					clearTimeout(timeoutId)
-					reject(error)
+					reject(error instanceof Error ? error : new Error(String(error)))
 				})
 		})
 	}

--- a/stonecrop/src/registry.ts
+++ b/stonecrop/src/registry.ts
@@ -85,17 +85,18 @@ export default class Registry {
 	}
 
 	/**
-	 * Resolve nested Doctype and Table fields in a schema by embedding child schemas inline.
+	 * Resolve nested Doctype fields in a schema by embedding child schemas inline.
 	 *
 	 * @remarks
 	 * Walks the schema array and for each field with `fieldtype: 'Doctype'` and a string
-	 * `options` value, looks up the referenced doctype in the registry and embeds its schema
-	 * as the field's `schema` property. Recurses for deeply nested doctypes.
+	 * `options` value, looks up the referenced doctype in the registry and:
 	 *
-	 * For fields with `fieldtype: 'Table'`, looks up the referenced child doctype and
-	 * auto-derives `columns` from its schema fields (unless columns are already provided).
-	 * Also sets sensible defaults for `component` (`'ATable'`) and `config` (`{ view: 'list' }`).
-	 * Row data is expected to come from the parent form's data model at `data[fieldname]`.
+	 * - If `cardinality: 'many'`: auto-derives `columns` from the child doctype's schema,
+	 *   sets `component: 'ATable'`, `config: { view: 'list' }`, and initializes `rows: []`.
+	 * - Otherwise (default/`cardinality: 'one'`): embeds the child schema as the field's
+	 *   `schema` property for 1:1 nested forms.
+	 *
+	 * Recurses for deeply nested doctypes. Circular references are protected against.
 	 *
 	 * Returns a new array — does not mutate the original schema.
 	 *
@@ -137,64 +138,52 @@ export default class Registry {
 					// Convert Immutable.List to plain array if needed
 					const childSchema: SchemaTypes[] = Array.isArray(doctype.schema) ? doctype.schema : Array.from(doctype.schema)
 
-					// Recurse into child schema to resolve deeply nested doctypes
-					seen.add(doctypeSlug)
-					const resolvedChild = this.resolveSchema(childSchema, seen)
-					seen.delete(doctypeSlug)
+					// Check cardinality to determine handling
+					const cardinality = 'cardinality' in field ? field.cardinality : undefined
 
-					return { ...field, schema: resolvedChild }
-				}
-			}
+					if (cardinality === 'many') {
+						// 1:many child table - derive columns, set component, config, rows
+						const resolved: Record<string, any> = { ...field }
 
-			// Resolve Table fieldtype — 1:many child doctype rendered as ATable
-			if (
-				'fieldtype' in field &&
-				field.fieldtype === 'Table' &&
-				'options' in field &&
-				typeof field.options === 'string'
-			) {
-				const doctypeSlug = field.options
+						// Auto-derive columns from child schema fields if not already provided
+						if (!('columns' in field) || !field.columns) {
+							resolved.columns = childSchema.map(childField => ({
+								name: childField.fieldname,
+								fieldname: childField.fieldname,
+								label: ('label' in childField && childField.label) || childField.fieldname,
+								fieldtype: 'fieldtype' in childField ? childField.fieldtype : 'Data',
+								align: ('align' in childField && childField.align) || 'left',
+								edit: 'edit' in childField ? childField.edit : true,
+								width: ('width' in childField && childField.width) || '20ch',
+							}))
+						}
 
-				// Circular reference protection
-				if (seen.has(doctypeSlug)) {
-					return { ...field }
-				}
+						// Set default component if not already specified
+						if (!resolved.component) {
+							resolved.component = 'ATable'
+						}
 
-				const doctype = this.registry[doctypeSlug]
-				if (doctype && doctype.schema) {
-					const childSchema: SchemaTypes[] = Array.isArray(doctype.schema) ? doctype.schema : Array.from(doctype.schema)
-					const resolved: Record<string, any> = { ...field }
+						// Set default config if not already specified
+						if (!('config' in field) || !field.config) {
+							resolved.config = { view: 'list' }
+						}
 
-					// Auto-derive columns from child schema fields if not already provided
-					if (!('columns' in field) || !field.columns) {
-						resolved.columns = childSchema.map(childField => ({
-							name: childField.fieldname,
-							fieldname: childField.fieldname,
-							label: ('label' in childField && childField.label) || childField.fieldname,
-							fieldtype: 'fieldtype' in childField ? childField.fieldtype : 'Data',
-							align: ('align' in childField && childField.align) || 'left',
-							edit: 'edit' in childField ? childField.edit : true,
-							width: ('width' in childField && childField.width) || '20ch',
-						}))
+						// Initialize rows to empty array so componentProps fallback
+						// routes data from the form's dataModel[fieldname]
+						if (!('rows' in field) || !field.rows) {
+							resolved.rows = []
+						}
+
+						return resolved as SchemaTypes
+					} else {
+						// 1:1 nested form (default cardinality: 'one')
+						// Recurse into child schema to resolve deeply nested doctypes
+						seen.add(doctypeSlug)
+						const resolvedChild = this.resolveSchema(childSchema, seen)
+						seen.delete(doctypeSlug)
+
+						return { ...field, schema: resolvedChild }
 					}
-
-					// Set default component if not already specified
-					if (!resolved.component) {
-						resolved.component = 'ATable'
-					}
-
-					// Set default config if not already specified
-					if (!('config' in field) || !field.config) {
-						resolved.config = { view: 'list' }
-					}
-
-					// Initialize rows to empty array so componentProps fallback
-					// routes data from the form's dataModel[fieldname]
-					if (!('rows' in field) || !field.rows) {
-						resolved.rows = []
-					}
-
-					return resolved as SchemaTypes
 				}
 			}
 
@@ -211,11 +200,13 @@ export default class Registry {
 	 * - Data, Text → `''`
 	 * - Check → `false`
 	 * - Int, Float, Decimal, Currency, Quantity → `0`
-	 * - Table → `[]`
-	 * - JSON, Doctype → `{}`
+	 * - JSON → `{}`
+	 * - Doctype with `cardinality: 'many'` → `[]`
+	 * - Doctype without `cardinality` or `cardinality: 'one'` → recursively initializes nested record
 	 * - All others → `null`
 	 *
-	 * For Doctype fields with a resolved `schema` array, recursively initializes the nested record.
+	 * For Doctype fields with a resolved `schema` array (cardinality: 'one'), recursively
+	 * initializes the nested record.
 	 *
 	 * @param schema - The schema array to derive defaults from
 	 * @returns A plain object with default values for each field
@@ -250,20 +241,24 @@ export default class Registry {
 				case 'Quantity':
 					record[field.fieldname] = 0
 					break
-				case 'Table':
-					record[field.fieldname] = []
-					break
 				case 'JSON':
 					record[field.fieldname] = {}
 					break
-				case 'Doctype':
-					// If nested schema is resolved, recursively initialize
-					if ('schema' in field && Array.isArray(field.schema)) {
+				case 'Doctype': {
+					// Check cardinality to determine initial value
+					const cardinality = 'cardinality' in field ? field.cardinality : undefined
+					if (cardinality === 'many') {
+						// 1:many child table - initialize as empty array
+						record[field.fieldname] = []
+					} else if ('schema' in field && Array.isArray(field.schema)) {
+						// 1:1 nested form with resolved schema - recursively initialize
 						record[field.fieldname] = this.initializeRecord(field.schema)
 					} else {
+						// 1:1 without resolved schema - empty object
 						record[field.fieldname] = {}
 					}
 					break
+				}
 				default:
 					record[field.fieldname] = null
 			}

--- a/stonecrop/src/stonecrop.ts
+++ b/stonecrop/src/stonecrop.ts
@@ -1,4 +1,4 @@
-import type { DataClient, WorkflowMeta } from '@stonecrop/schema'
+import type { DataClient } from '@stonecrop/schema'
 import { reactive } from 'vue'
 
 import Doctype from './doctype'

--- a/stonecrop/tests/actions/hst-integration.spec.ts
+++ b/stonecrop/tests/actions/hst-integration.spec.ts
@@ -24,7 +24,9 @@ describe('Field Trigger Integration', () => {
 		registerGlobalAction('validateEmailPrimary', validateEmailPrimary)
 
 		// Create a doctype with field triggers in actions map
-		const schema = List([{ fieldname: 'emailAddress', fieldtype: 'Table', label: 'Email Addresses' }])
+		const schema = List([
+			{ fieldname: 'emailAddress', fieldtype: 'Doctype', cardinality: 'many', label: 'Email Addresses' },
+		])
 		const workflow: UnknownMachineConfig = {
 			id: 'task',
 			initial: 'draft',

--- a/stonecrop/tests/composable-hst.spec.ts
+++ b/stonecrop/tests/composable-hst.spec.ts
@@ -94,7 +94,7 @@ describe('useStonecrop HST mode', () => {
 		expect(vm.formData).toBeDefined()
 		expect(vm.resolvedSchema).toBeDefined()
 		expect(vm.loadNestedData).toBeDefined()
-		expect(vm.saveRecursive).toBeDefined()
+		expect(vm.collectRecordPayload).toBeDefined()
 		expect(vm.createNestedContext).toBeDefined()
 	})
 
@@ -415,6 +415,44 @@ describe('useStonecrop HST mode', () => {
 		expect(nested).toBeDefined()
 	})
 
+	it('loadNestedData returns existing data when found in HST', async () => {
+		const addressDoctype = createDoctype('Address', [
+			{ fieldname: 'street', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'city', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+		])
+		registry.addDoctype(addressDoctype)
+
+		const customerDoctype = createDoctype('Customer', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'address', fieldtype: 'Doctype', options: 'address' } as SchemaTypes,
+		])
+		registry.addDoctype(customerDoctype)
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ registry, doctype: customerDoctype, recordId: 'cust-99' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
+		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const vm = wrapper.vm as any
+		const existingAddress = { street: '456 Oak Ave', city: 'Boston' }
+		vm.handleHSTChange({
+			path: 'customer.cust-99.address',
+			value: existingAddress,
+			fieldname: 'address',
+		})
+
+		const nested = vm.loadNestedData('customer.cust-99.address', addressDoctype, 'addr-1')
+		expect(nested).toEqual(existingAddress)
+	})
+
 	it('operationLog API is available in HST mode', async () => {
 		const taskDoctype = createDoctype('Task')
 		registry.addDoctype(taskDoctype)
@@ -488,16 +526,27 @@ describe('useStonecrop HST mode', () => {
 		expect(() => opLog.clear()).not.toThrow()
 	})
 
-	it('saveRecursive throws when HST not initialized', async () => {
-		const taskDoctype = createDoctype('Task')
-		registry.addDoctype(taskDoctype)
+	it('collectRecordPayload collects array data for cardinality: many fields', async () => {
+		const itemDoctype = createDoctype('Item', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'qty', fieldtype: 'Int', component: 'ANumericInput' } as SchemaTypes,
+		])
+		registry.addDoctype(itemDoctype)
 
-		// Before mount, hstStore won't be initialized
+		const orderDoctype = createDoctype('Order', [
+			{ fieldname: 'order_number', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'items',
+				fieldtype: 'Doctype',
+				cardinality: 'many',
+				options: 'item',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(orderDoctype)
+
 		const TestComponent = defineComponent({
 			setup() {
-				const result = useStonecrop({ registry, doctype: taskDoctype })
-				// Call saveRecursive before mount completes
-				return { ...result, taskDoctype }
+				return useStonecrop({ registry, doctype: orderDoctype, recordId: 'order-1' })
 			},
 			template: '<div>test</div>',
 		})
@@ -505,14 +554,270 @@ describe('useStonecrop HST mode', () => {
 		const wrapper = mount(TestComponent, {
 			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
 		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
 
 		const vm = wrapper.vm as any
-		// saveRecursive should handle missing store gracefully
-		try {
-			await vm.saveRecursive(taskDoctype, 'task-1')
-		} catch (e: any) {
-			expect(e.message).toContain('HST store not initialized')
-		}
+
+		vm.handleHSTChange({
+			path: 'order.order-1.order_number',
+			value: 'ORD-001',
+			fieldname: 'order_number',
+		})
+
+		const itemsData = [
+			{ name: 'Item 1', qty: 5 },
+			{ name: 'Item 2', qty: 10 },
+		]
+		stonecrop.getStore().set('order.order-1.items', itemsData)
+
+		const payload = vm.collectRecordPayload(orderDoctype, 'order-1')
+
+		expect(payload.order_number).toBe('ORD-001')
+		expect(payload.items).toBeDefined()
+		expect(Array.isArray(payload.items)).toBe(true)
+		expect(payload.items).toHaveLength(2)
+		expect(payload.items[0].name).toBe('Item 1')
+		expect(payload.items[1].qty).toBe(10)
+	})
+
+	it('collectRecordPayload handles empty array for cardinality: many fields', async () => {
+		const itemDoctype = createDoctype('Item', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+		])
+		registry.addDoctype(itemDoctype)
+
+		const orderDoctype = createDoctype('Order', [
+			{ fieldname: 'order_number', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'items',
+				fieldtype: 'Doctype',
+				cardinality: 'many',
+				options: 'item',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(orderDoctype)
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ registry, doctype: orderDoctype, recordId: 'order-2' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
+		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const vm = wrapper.vm as any
+
+		vm.handleHSTChange({
+			path: 'order.order-2.order_number',
+			value: 'ORD-002',
+			fieldname: 'order_number',
+		})
+
+		const payload = vm.collectRecordPayload(orderDoctype, 'order-2')
+
+		expect(payload.order_number).toBe('ORD-002')
+		expect(payload.items).toBeDefined()
+		expect(Array.isArray(payload.items)).toBe(true)
+		expect(payload.items).toHaveLength(0)
+	})
+
+	it('collectRecordPayload collects nested 1:1 doctype fields', async () => {
+		const addressDoctype = createDoctype('Address', [
+			{ fieldname: 'street', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'city', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+		])
+		registry.addDoctype(addressDoctype)
+
+		const customerDoctype = createDoctype('Customer', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'address',
+				fieldtype: 'Doctype',
+				options: 'address',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(customerDoctype)
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ registry, doctype: customerDoctype, recordId: 'cust-1' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
+		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const vm = wrapper.vm as any
+
+		vm.handleHSTChange({
+			path: 'customer.cust-1.name',
+			value: 'John Doe',
+			fieldname: 'name',
+		})
+
+		stonecrop.getStore().set('customer.cust-1.address', {
+			street: '123 Oak St',
+			city: 'Portland',
+		})
+
+		const payload = vm.collectRecordPayload(customerDoctype, 'cust-1')
+
+		expect(payload.name).toBe('John Doe')
+		expect(payload.address).toBeDefined()
+		expect(payload.address.street).toBe('123 Oak St')
+		expect(payload.address.city).toBe('Portland')
+	})
+
+	it('collectRecordPayload recursively collects 1:many inside nested 1:1', async () => {
+		const phoneDoctype = createDoctype('Phone', [
+			{ fieldname: 'number', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'type', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+		])
+		registry.addDoctype(phoneDoctype)
+
+		const addressDoctype = createDoctype('Address', [
+			{ fieldname: 'street', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'city', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'phones',
+				fieldtype: 'Doctype',
+				cardinality: 'many',
+				options: 'phone',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(addressDoctype)
+
+		const customerDoctype = createDoctype('Customer', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'address',
+				fieldtype: 'Doctype',
+				options: 'address',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(customerDoctype)
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ registry, doctype: customerDoctype, recordId: 'cust-2' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
+		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const vm = wrapper.vm as any
+
+		vm.handleHSTChange({
+			path: 'customer.cust-2.name',
+			value: 'Jane Doe',
+			fieldname: 'name',
+		})
+
+		stonecrop.getStore().set('customer.cust-2.address', {
+			street: '456 Pine St',
+			city: 'Portland',
+		})
+
+		stonecrop.getStore().set('customer.cust-2.address.phones', [
+			{ number: '555-1234', type: 'mobile' },
+			{ number: '555-5678', type: 'work' },
+		])
+
+		const payload = vm.collectRecordPayload(customerDoctype, 'cust-2')
+
+		expect(payload.name).toBe('Jane Doe')
+		expect(payload.address).toBeDefined()
+		expect(payload.address.street).toBe('456 Pine St')
+		expect(payload.address.city).toBe('Portland')
+		expect(payload.address.phones).toBeDefined()
+		expect(Array.isArray(payload.address.phones)).toBe(true)
+		expect(payload.address.phones).toHaveLength(2)
+		expect(payload.address.phones[0].number).toBe('555-1234')
+		expect(payload.address.phones[1].type).toBe('work')
+	})
+
+	it('collectRecordPayload collects deeply nested 1:1 inside 1:1', async () => {
+		const coordinatesDoctype = createDoctype('Coordinates', [
+			{ fieldname: 'lat', fieldtype: 'Float', component: 'ANumericInput' } as SchemaTypes,
+			{ fieldname: 'lng', fieldtype: 'Float', component: 'ANumericInput' } as SchemaTypes,
+		])
+		registry.addDoctype(coordinatesDoctype)
+
+		const addressDoctype = createDoctype('Address', [
+			{ fieldname: 'street', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{ fieldname: 'city', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'coordinates',
+				fieldtype: 'Doctype',
+				options: 'coordinates',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(addressDoctype)
+
+		const customerDoctype = createDoctype('Customer', [
+			{ fieldname: 'name', fieldtype: 'Data', component: 'ATextInput' } as SchemaTypes,
+			{
+				fieldname: 'address',
+				fieldtype: 'Doctype',
+				options: 'address',
+			} as SchemaTypes,
+		])
+		registry.addDoctype(customerDoctype)
+
+		const TestComponent = defineComponent({
+			setup() {
+				return useStonecrop({ registry, doctype: customerDoctype, recordId: 'cust-3' })
+			},
+			template: '<div>test</div>',
+		})
+
+		const wrapper = mount(TestComponent, {
+			global: { provide: { $registry: registry, $stonecrop: stonecrop } },
+		})
+		await wrapper.vm.$nextTick()
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const vm = wrapper.vm as any
+
+		vm.handleHSTChange({
+			path: 'customer.cust-3.name',
+			value: 'Bob Smith',
+			fieldname: 'name',
+		})
+
+		stonecrop.getStore().set('customer.cust-3.address', {
+			street: '789 Elm St',
+			city: 'Seattle',
+		})
+
+		stonecrop.getStore().set('customer.cust-3.address.coordinates', {
+			lat: 47.6062,
+			lng: -122.3321,
+		})
+
+		const payload = vm.collectRecordPayload(customerDoctype, 'cust-3')
+
+		expect(payload.name).toBe('Bob Smith')
+		expect(payload.address).toBeDefined()
+		expect(payload.address.street).toBe('789 Elm St')
+		expect(payload.address.coordinates).toBeDefined()
+		expect(payload.address.coordinates.lat).toBe(47.6062)
+		expect(payload.address.coordinates.lng).toBe(-122.3321)
 	})
 })
 

--- a/stonecrop/tests/hst/integration.spec.ts
+++ b/stonecrop/tests/hst/integration.spec.ts
@@ -63,8 +63,8 @@ describe('HST Real Component Integration', () => {
 			// JSON field for complex data
 			{ fieldname: 'metadata', fieldtype: 'JSON', label: 'Metadata', component: 'ATextInput' },
 
-			// Table field for related items
-			{ fieldname: 'subtasks', fieldtype: 'Table', label: 'Subtasks', component: 'ATable' },
+			// Doctype field with cardinality:many for related items
+			{ fieldname: 'subtasks', fieldtype: 'Doctype', cardinality: 'many', label: 'Subtasks', component: 'ATable' },
 		] as SchemaTypes[])
 
 		const mockWorkflow: UnknownMachineConfig = {

--- a/stonecrop/tests/hst/reactivity.spec.ts
+++ b/stonecrop/tests/hst/reactivity.spec.ts
@@ -195,7 +195,7 @@ describe('HST Vue Reactivity', () => {
 		const mockSchema = List([
 			{ fieldname: 'name', fieldtype: 'Data', label: 'Name', component: 'MockATextInput' },
 			{ fieldname: 'active', fieldtype: 'Check', label: 'Active', component: 'MockACheckbox' },
-			{ fieldname: 'items', fieldtype: 'Table', label: 'Items', component: 'MockATable' },
+			{ fieldname: 'items', fieldtype: 'Doctype', cardinality: 'many', label: 'Items', component: 'MockATable' },
 		] as SchemaTypes[])
 
 		const mockWorkflow: UnknownMachineConfig = {

--- a/stonecrop/tests/hst/usability.spec.ts
+++ b/stonecrop/tests/hst/usability.spec.ts
@@ -25,9 +25,9 @@ describe('HST Edge Cases & Performance', () => {
 		const complexSchema = List([
 			{ fieldname: 'name', fieldtype: 'Data', label: 'Name', component: 'ATextInput' },
 			{ fieldname: 'metadata', fieldtype: 'JSON', label: 'Metadata', component: 'ATextInput' },
-			{ fieldname: 'tags', fieldtype: 'Table', label: 'Tags', component: 'ATable' },
+			{ fieldname: 'tags', fieldtype: 'Doctype', cardinality: 'many', label: 'Tags', component: 'ATable' },
 			{ fieldname: 'config', fieldtype: 'JSON', label: 'Config', component: 'ATextInput' },
-			{ fieldname: 'items', fieldtype: 'Table', label: 'Items', component: 'ATable' },
+			{ fieldname: 'items', fieldtype: 'Doctype', cardinality: 'many', label: 'Items', component: 'ATable' },
 			{ fieldname: 'nested_data', fieldtype: 'JSON', label: 'Nested Data', component: 'ATextInput' },
 		] as SchemaTypes[])
 

--- a/stonecrop/tests/nested-doctype.spec.ts
+++ b/stonecrop/tests/nested-doctype.spec.ts
@@ -128,20 +128,21 @@ describe('Nested Doctype Support', () => {
 			expect(resolved[1]).toEqual(expect.objectContaining({ fieldname: 'active', fieldtype: 'Check' }))
 		})
 
-		it('resolves a Table field by auto-deriving columns from child doctype', () => {
+		it('resolves a Doctype field with cardinality:many by auto-deriving columns from child doctype', () => {
 			const schema = [
 				{ fieldname: 'customer_name', fieldtype: 'Data', component: 'ATextInput' },
-				{ fieldname: 'addresses', fieldtype: 'Table', options: 'address' },
+				{ fieldname: 'addresses', fieldtype: 'Doctype', cardinality: 'many', options: 'address' },
 			]
 			const resolved = registry.resolveSchema(schema)
 
-			// Non-Table fields are unchanged
+			// Non-Doctype fields are unchanged
 			expect(resolved[0]).toEqual(expect.objectContaining({ fieldname: 'customer_name', fieldtype: 'Data' }))
 
-			// Table field has auto-derived columns, component, config, and rows
+			// Doctype field with cardinality:many has auto-derived columns, component, config, and rows
 			const tableField = resolved[1] as any
 			expect(tableField.fieldname).toBe('addresses')
-			expect(tableField.fieldtype).toBe('Table')
+			expect(tableField.fieldtype).toBe('Doctype')
+			expect(tableField.cardinality).toBe('many')
 			expect(tableField.component).toBe('ATable')
 			expect(tableField.config).toEqual({ view: 'list' })
 			expect(tableField.rows).toEqual([])
@@ -156,7 +157,7 @@ describe('Nested Doctype Support', () => {
 			expect(tableField.columns[3]).toEqual(expect.objectContaining({ name: 'zip_code' }))
 		})
 
-		it('preserves user-provided columns on Table fields', () => {
+		it('preserves user-provided columns on Doctype cardinality:many fields', () => {
 			const customColumns = [
 				{ name: 'street', label: 'Street Address', fieldtype: 'Data', align: 'left', edit: true, width: '30ch' },
 				{ name: 'city', label: 'City', fieldtype: 'Data', align: 'left', edit: false, width: '15ch' },
@@ -164,7 +165,8 @@ describe('Nested Doctype Support', () => {
 			const schema = [
 				{
 					fieldname: 'addresses',
-					fieldtype: 'Table',
+					fieldtype: 'Doctype',
+					cardinality: 'many',
 					options: 'address',
 					columns: customColumns,
 				},
@@ -177,11 +179,12 @@ describe('Nested Doctype Support', () => {
 			expect(tableField.columns).toHaveLength(2)
 		})
 
-		it('preserves user-provided config and component on Table fields', () => {
+		it('preserves user-provided config and component on Doctype cardinality:many fields', () => {
 			const schema = [
 				{
 					fieldname: 'addresses',
-					fieldtype: 'Table',
+					fieldtype: 'Doctype',
+					cardinality: 'many',
 					options: 'address',
 					component: 'MyCustomTable',
 					config: { view: 'tree' as const, defaultTreeExpansion: 'root' as const },
@@ -194,8 +197,8 @@ describe('Nested Doctype Support', () => {
 			expect(tableField.config).toEqual({ view: 'tree', defaultTreeExpansion: 'root' })
 		})
 
-		it('does not mutate original schema for Table fields', () => {
-			const schema = [{ fieldname: 'addresses', fieldtype: 'Table', options: 'address' }]
+		it('does not mutate original schema for Doctype cardinality:many fields', () => {
+			const schema = [{ fieldname: 'addresses', fieldtype: 'Doctype', cardinality: 'many', options: 'address' }]
 			const original = schema[0]
 			registry.resolveSchema(schema)
 
@@ -203,8 +206,8 @@ describe('Nested Doctype Support', () => {
 			expect('component' in original).toBe(false)
 		})
 
-		it('gracefully handles missing doctype for Table fields', () => {
-			const schema = [{ fieldname: 'items', fieldtype: 'Table', options: 'nonexistent' }]
+		it('gracefully handles missing doctype for Doctype cardinality:many fields', () => {
+			const schema = [{ fieldname: 'items', fieldtype: 'Doctype', cardinality: 'many', options: 'nonexistent' }]
 			const resolved = registry.resolveSchema(schema)
 
 			const tableField = resolved[0] as any
@@ -224,7 +227,7 @@ describe('Nested Doctype Support', () => {
 				{ fieldname: 'amount', fieldtype: 'Decimal', component: 'ANumericInput' },
 				{ fieldname: 'cost', fieldtype: 'Currency', component: 'ANumericInput' },
 				{ fieldname: 'qty', fieldtype: 'Quantity', component: 'ANumericInput' },
-				{ fieldname: 'items', fieldtype: 'Table', component: 'ATable' },
+				{ fieldname: 'items', fieldtype: 'Doctype', cardinality: 'many', component: 'ATable' },
 				{ fieldname: 'meta', fieldtype: 'JSON', component: 'ACodeEditor' },
 				{ fieldname: 'birthday', fieldtype: 'Date', component: 'ADatePicker' },
 			]

--- a/stonecrop/tests/validation.spec.ts
+++ b/stonecrop/tests/validation.spec.ts
@@ -183,7 +183,8 @@ describe('Schema Validator', () => {
 				{
 					fieldname: 'items',
 					label: 'Items',
-					fieldtype: 'Table',
+					fieldtype: 'Doctype',
+					cardinality: 'many',
 				},
 			])
 


### PR DESCRIPTION
Replaces the separate `Table` fieldtype with `cardinality: 'one' | 'many'` on `Doctype`. A `Doctype` field with `cardinality: 'many'` controls whether `resolveSchema()` derives ATable columns. Without setting the cardinality (defaulting to `'one'`), it embeds a nested form schema.

The `TableDoctypeSchema` type is removed entirely; `DoctypeSchema` becomes a discriminated union on `cardinality`. No backwards compatibility needed.