### PR TITLE
[project] fix various bugs

### DIFF
--- a/aform/README.md
+++ b/aform/README.md
@@ -72,18 +72,28 @@ When `id` is falsy, the component shows a `—` placeholder and hides the naviga
 
 ### Filter function
 
-Provide `filterFunction` to enable the search dropdown. The function receives the current input text and must return `AFormLinkValue[]` or a `Promise<AFormLinkValue[]>`.
+Provide `filterFunction` to enable the search dropdown. The function receives a search string and must return `AFormLinkValue[]` or a `Promise<AFormLinkValue[]>`.
+
+The function is called in two distinct situations:
+
+1. **On user interaction** — when the user focuses or types into the field, the current input text is passed as the search string.
+2. **On mount (and on id change)** — when the field has an `id` but no `displayText`, the function is called automatically with the existing `id` string so the display name can be resolved without user interaction. The first result whose `id` matches is used.
+
+Because of case 2, implementations should handle both name-based searches (partial strings typed by the user) and exact id lookups (full id strings passed on mount). A common pattern is to attempt both:
 
 ```typescript
 // Sync
 const filterFunction = (search: string): AFormLinkValue[] =>
   records
-    .filter(r => r.name.toLowerCase().includes(search.toLowerCase()))
+    .filter(r =>
+      r.id === search ||                                  // exact id match (mount-time resolution)
+      r.name.toLowerCase().includes(search.toLowerCase()) // name search (user typing)
+    )
     .map(r => ({ id: r.id, displayText: r.name }))
 
 // Async — set isAsync: true for loading indicator
 const filterFunction = async (search: string): Promise<AFormLinkValue[]> => {
-  const results = await api.search(search)
+  const results = await api.search(search)  // API should handle both id and name queries
   return results.map(r => ({ id: r.id, displayText: r.name }))
 }
 ```

--- a/aform/README.md
+++ b/aform/README.md
@@ -30,6 +30,26 @@ This registers all components globally. They can also be imported individually.
 
 ---
 
+## AForm
+
+### Field width
+
+Set `width` on any schema field to control its share of the form row. The value is any valid CSS size and is applied as `flex-basis` + `width` directly on the field's flex item:
+
+```json
+{ "fieldname": "notes", "fieldtype": "Text", "component": "ATextInput", "label": "Notes", "width": "100%" }
+```
+
+| Value | Effect |
+|---|---|
+| `"100%"` | Field spans the full form row (forces a line-break before and after) |
+| `"50%"` | Field takes half the row; neighbouring fields fill the rest |
+| `"40ch"` | Field starts at 40 characters wide and grows with available space |
+
+Fields without `width` continue to share space equally (`flex-grow: 1; min-width: 20ch`).
+
+---
+
 ## AFormLink
 
 A form input for selecting and navigating to linked documents (`fieldtype: 'Link'`). Combines a searchable text input, an optional dropdown of results, and a navigation arrow button.

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -23,6 +23,7 @@
 				:is="componentObj.component"
 				v-else-if="!componentObj.hidden"
 				v-model="childModels[key].value"
+				:style="fieldStyle(componentObj)"
 				:schema="componentObj"
 				:data="dataModel[componentObj.fieldname]"
 				:mode="resolvedMode(componentObj)"
@@ -82,7 +83,7 @@ const componentProps = (componentObj: SchemaTypes) => {
 	for (const [key, value] of Object.entries(componentObj)) {
 		// 'mode' is excluded here because it is handled by resolvedMode()
 		// and passed explicitly via :mode to avoid conflicting with the form-level defaults.
-		if (!['component', 'fieldtype', 'hidden', 'mode'].includes(key)) {
+		if (!['component', 'fieldtype', 'hidden', 'mode', 'width'].includes(key)) {
 			propsToPass[key] = value
 		}
 	}
@@ -98,6 +99,12 @@ const componentProps = (componentObj: SchemaTypes) => {
 	}
 
 	return propsToPass
+}
+
+const fieldStyle = (componentObj: SchemaTypes): Record<string, string> => {
+	const width = (componentObj as { width?: string }).width
+	if (!width) return {}
+	return { flexBasis: width, width }
 }
 
 const effectiveFormMode = computed(() => mode ?? 'edit')
@@ -150,6 +157,10 @@ const childModels = computed(() => childModelsCache.value)
 	flex-grow: 1;
 	min-width: 20ch;
 	margin-bottom: 1rem;
+}
+.aform__grid--full {
+	flex-basis: 100%;
+	width: 100%;
 }
 .aform_input-field {
 	outline: 1px solid var(--sc-input-border-color);

--- a/aform/src/components/form/AFormLink.vue
+++ b/aform/src/components/form/AFormLink.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 import { vOnClickOutside } from '@vueuse/components'
-import { computed, inject, ref } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
 
 import type { AFormLinkNavigator, AFormLinkValue, ComponentProps } from '../../types'
 import { deserializeFunction } from '../../utils/deserialize'
@@ -91,6 +91,28 @@ const activeIndex = ref<number | null>(null)
 
 const navigator = inject<AFormLinkNavigator | null>('aformLinkNavigator', null)
 
+type FilterFn = (search: string) => AFormLinkValue[] | Promise<AFormLinkValue[]>
+
+watch(
+	() => modelValue.value?.id,
+	async id => {
+		if (!id || modelValue.value.displayText || !filterFunction) return
+		try {
+			const fn: FilterFn =
+				typeof filterFunction === 'string' ? deserializeFunction<FilterFn>(filterFunction) : filterFunction
+			const results = await fn(String(id))
+			const match = results.find(r => String(r.id) === String(id))
+			if (match?.displayText) {
+				searchText.value = match.displayText
+				modelValue.value = { ...modelValue.value, displayText: match.displayText }
+			}
+		} catch {
+			// silent — fall back to showing the raw id
+		}
+	},
+	{ immediate: true }
+)
+
 const handleNavigate = () => {
 	if (navigator && doctype) {
 		navigator.navigate(doctype, modelValue.value.id)
@@ -103,7 +125,6 @@ const openDropdown = async (text: string) => {
 	dropdownOpen.value = true
 	if (isAsync) loading.value = true
 	try {
-		type FilterFn = (search: string) => AFormLinkValue[] | Promise<AFormLinkValue[]>
 		const fn: FilterFn =
 			typeof filterFunction === 'string' ? deserializeFunction<FilterFn>(filterFunction) : filterFunction
 		dropdownResults.value = (await fn(text)) ?? []

--- a/aform/src/types/index.ts
+++ b/aform/src/types/index.ts
@@ -138,8 +138,9 @@ export type FormSchema = BaseSchema & {
 	name?: string
 
 	/**
-	 * The width of the field element.
-	 * @beta
+	 * CSS width for the field's flex item in the AForm grid.
+	 * Applied as `flex-basis` and `width` on the rendered component element.
+	 * Use `"100%"` to make the field span the full form row.
 	 */
 	width?: string
 

--- a/aform/tests/form.spec.ts
+++ b/aform/tests/form.spec.ts
@@ -279,4 +279,63 @@ describe('AForm Component', () => {
 			expect(input.attributes('maxlength')).toBeUndefined()
 		})
 	})
+
+	describe('width schema property', () => {
+		it('applies flex-basis and width style when width is set in schema', async () => {
+			const MockField = defineComponent({
+				name: 'MockField',
+				props: ['label', 'mode', 'schema', 'data'],
+				template: '<div class="aform_form-element mock-field"></div>',
+			})
+
+			const wrapper = mount(AForm, {
+				props: {
+					schema: [
+						{
+							fieldname: 'canvas',
+							component: 'MockField',
+							label: 'Canvas',
+							fieldtype: 'Display',
+							width: '100%',
+						},
+					] as SchemaTypes[],
+					data: {},
+				},
+				global: { components: { MockField } },
+			})
+
+			await wrapper.vm.$nextTick()
+			const field = wrapper.findComponent(MockField)
+			expect(field.element.style.flexBasis).toBe('100%')
+			expect(field.element.style.width).toBe('100%')
+		})
+
+		it('does not apply width style when width is absent in schema', async () => {
+			const MockField = defineComponent({
+				name: 'MockField',
+				props: ['label', 'mode', 'schema', 'data'],
+				template: '<div class="aform_form-element mock-field"></div>',
+			})
+
+			const wrapper = mount(AForm, {
+				props: {
+					schema: [
+						{
+							fieldname: 'name',
+							component: 'MockField',
+							label: 'Name',
+							fieldtype: 'Data',
+						},
+					] as SchemaTypes[],
+					data: {},
+				},
+				global: { components: { MockField } },
+			})
+
+			await wrapper.vm.$nextTick()
+			const field = wrapper.findComponent(MockField)
+			expect(field.element.style.flexBasis).toBe('')
+			expect(field.element.style.width).toBe('')
+		})
+	})
 })

--- a/aform/tests/formlink.spec.ts
+++ b/aform/tests/formlink.spec.ts
@@ -15,11 +15,50 @@ describe('AFormLink component', () => {
 		expect(wrapper.find('input').element.value).toBe('Acme Corp')
 	})
 
-	it('falls back to id when displayText is omitted', () => {
+	it('falls back to id when displayText is omitted and no filterFunction is provided', () => {
 		const wrapper = mount(AFormLink, {
 			props: { modelValue: { id: 'CUST-001' } },
 		})
 		expect(wrapper.find('input').element.value).toBe('CUST-001')
+	})
+
+	it('resolves display text on mount when id is set but displayText is absent', async () => {
+		const filterFunction = vi.fn(async (_: string) => [{ id: 'PP-001', displayText: 'Q1 2026' }])
+		const wrapper = mount(AFormLink, {
+			props: { modelValue: { id: 'PP-001' }, filterFunction },
+		})
+
+		await flushPromises()
+
+		expect(filterFunction).toHaveBeenCalledWith('PP-001')
+		expect(wrapper.find('input').element.value).toBe('Q1 2026')
+	})
+
+	it('does not call filterFunction on mount when displayText is already present', async () => {
+		const filterFunction = vi.fn(async (_: string) => [{ id: 'CUST-001', displayText: 'Acme Corp' }])
+		mount(AFormLink, {
+			props: { modelValue: { id: 'CUST-001', displayText: 'Acme Corp' }, filterFunction },
+		})
+
+		await flushPromises()
+
+		expect(filterFunction).not.toHaveBeenCalled()
+	})
+
+	it('resolves display text when modelValue id changes after mount', async () => {
+		const filterFunction = vi.fn(async (id: string) => [{ id, displayText: `Name for ${id}` }])
+		const wrapper = mount(AFormLink, {
+			props: { modelValue: { id: '' }, filterFunction },
+		})
+
+		await flushPromises()
+		expect(filterFunction).not.toHaveBeenCalled()
+
+		await wrapper.setProps({ modelValue: { id: 'NEW-001' } })
+		await flushPromises()
+
+		expect(filterFunction).toHaveBeenCalledWith('NEW-001')
+		expect(wrapper.find('input').element.value).toBe('Name for NEW-001')
 	})
 
 	it('shows empty input when id is falsy', () => {

--- a/common/changes/@stonecrop/aform/development_2026-05-13-09-57.json
+++ b/common/changes/@stonecrop/aform/development_2026-05-13-09-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "run filter function on mount of AFormLink",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/aform/development_2026-05-13-10-37.json
+++ b/common/changes/@stonecrop/aform/development_2026-05-13-10-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "correctly apply field width input from doctype schema",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/desktop/development_2026-05-13-09-42.json
+++ b/common/changes/@stonecrop/desktop/development_2026-05-13-09-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/desktop",
+      "comment": "fetch record details directly on navigation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/desktop"
+}

--- a/common/changes/@stonecrop/graphql-middleware/development_2026-05-13-10-20.json
+++ b/common/changes/@stonecrop/graphql-middleware/development_2026-05-13-10-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/graphql-middleware",
+      "comment": "allow Display fieldtype for fields without db backing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/graphql-middleware"
+}

--- a/common/changes/@stonecrop/stonecrop/development_2026-05-13-09-42.json
+++ b/common/changes/@stonecrop/stonecrop/development_2026-05-13-09-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "accept doctype as a string in getRecord",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(@envelop/core@5.5.1)(crossws@0.3.5)(graphql@16.13.2)(h3@1.15.11)(use-sync-external-store@1.6.0)
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
       '@rushstack/heft':
         specifier: ^1.2.17
         version: 1.2.17(@types/node@24.12.4)
@@ -699,12 +702,24 @@ importers:
       '@vitest/ui':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
+      eslint:
+        specifier: ^10.3.0
+        version: 10.3.0(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.3.0(jiti@2.6.1))
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       stonecrop-rig:
         specifier: workspace:*
         version: link:../rigs/stonecrop-rig
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.1
+        version: 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@24.12.4)(jiti@2.6.1)(sass@1.97.2)(terser@5.46.2)(yaml@2.8.4)

--- a/common/reviews/api/stonecrop.api.md
+++ b/common/reviews/api/stonecrop.api.md
@@ -705,7 +705,7 @@ export class Stonecrop {
     markIrreversible: (operationId: string, reason: string) => void;
     logAction: (doctype: string, actionName: string, recordIds?: string[], result?: "success" | "failure" | "pending", error?: string) => string;
     }, "undo" | "redo" | "configure" | "addOperation" | "startBatch" | "commitBatch" | "cancelBatch" | "clear" | "getOperationsFor" | "getSnapshot" | "markIrreversible" | "logAction">>;
-    getRecord(doctype: Doctype, recordId: string): Promise<void>;
+    getRecord(doctype: string | Doctype, recordId: string): Promise<void>;
     getRecordById(doctype: string | Doctype, recordId: string): HSTNode | undefined;
     getRecordIds(doctype: string | Doctype): string[];
     getRecords(doctype: Doctype): Promise<void>;

--- a/desktop/src/components/Desktop.vue
+++ b/desktop/src/components/Desktop.vue
@@ -678,23 +678,24 @@ const handleClick = async (event: Event) => {
 	}
 }
 
-const loadRecordData = () => {
-	if (!stonecrop.value || !currentDoctype.value) return
+const loadRecordData = async () => {
+	if (!stonecrop.value || !currentDoctype.value || isNewRecord.value) return
 
-	loading.value = true
+	// Record already in HST — nothing to fetch.
+	if (stonecrop.value.getRecordById(currentDoctype.value, currentRecordId.value)) return
 
-	try {
-		if (!isNewRecord.value) {
-			// For existing records, ensure the record exists in HST.
-			// The computed currentViewData will automatically read from HST.
-			stonecrop.value.getRecordById(currentDoctype.value, currentRecordId.value)
+	// Record absent and a client is configured — fetch directly so the form
+	// populates even when the list view was never visited (direct URL navigation).
+	if (stonecrop.value.getClient()) {
+		loading.value = true
+		try {
+			await stonecrop.value.getRecord(currentDoctype.value, currentRecordId.value)
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.warn('Error fetching record:', error)
+		} finally {
+			loading.value = false
 		}
-		// For new records, currentViewData computed property will return {} automatically.
-	} catch (error) {
-		// eslint-disable-next-line no-console
-		console.warn('Error loading record data:', error)
-	} finally {
-		loading.value = false
 	}
 }
 
@@ -708,7 +709,7 @@ watch(
 		} else if (currentView.value === 'record' && currentDoctype.value && currentRecordId.value) {
 			// Emit load-record event so host app can fetch and populate HST
 			emit('load-record', { doctype: currentDoctype.value, recordId: currentRecordId.value })
-			loadRecordData()
+			void loadRecordData()
 		}
 	},
 	{ immediate: true }

--- a/desktop/tests/desktop/router.spec.ts
+++ b/desktop/tests/desktop/router.spec.ts
@@ -156,6 +156,46 @@ describe('Desktop – internal router (no routeAdapter)', () => {
 		expect(wrapper.find('.desktop').exists()).toBe(true)
 	})
 
+	it('fetches record directly when navigating to record URL without prior list visit', async () => {
+		const mockGetRecord = vi.fn().mockResolvedValue({ id: 'rec-1', title: 'Fetched', status: 'draft' })
+		const mockClient = {
+			getRecord: mockGetRecord,
+			getRecords: vi.fn().mockResolvedValue([]),
+			dispatchAction: vi.fn(),
+		}
+
+		const testRouter = createRouter({ history: createMemoryHistory(), routes: routerTestRoutes })
+		const registry = new Registry(testRouter)
+		const stonecrop = new Stonecrop(registry, undefined, { client: mockClient as any })
+
+		const doctype = buildDoctype('task', 'draft', {
+			draft: { on: { SUBMIT: 'submitted' } },
+			submitted: { type: 'final' },
+		})
+		registry.addDoctype(doctype)
+		// Deliberately NO stonecrop.addRecord() — simulates direct URL navigation without prior list visit
+
+		await testRouter.push('/task/rec-1')
+		await testRouter.isReady()
+
+		mount(Desktop, {
+			global: {
+				plugins: [makeStonecropPlugin(registry, stonecrop), testRouter],
+				stubs: { AForm: true, ActionSet: true, SheetNav: true, CommandPalette: true },
+			},
+		})
+
+		await nextTick()
+		await nextTick() // allow async loadRecordData to settle
+
+		// Desktop must have attempted a direct fetch for the missing record
+		expect(mockGetRecord).toHaveBeenCalled()
+		// Record should now be in HST
+		const record = stonecrop.getRecordById('task', 'rec-1')
+		expect(record).toBeDefined()
+		expect(record?.get('title')).toBe('Fetched')
+	})
+
 	it('reads doctype and recordId from catch-all pathMatch params', async () => {
 		const testRouter = createRouter({ history: createMemoryHistory(), routes: routerTestRoutes })
 		const registry = new Registry(testRouter)

--- a/docs/reference/graphql-middleware.md
+++ b/docs/reference/graphql-middleware.md
@@ -29,7 +29,7 @@ import { ValidationError } from '@stonecrop/graphql_middleware'
 
 ### buildListQuery
 
-Build a GraphQL connection query to fetch a list of records. Only declares variables ($limit, $offset, $orderBy) that are actually used in the query, avoiding GraphQL spec §5.8.3 violations from unused variable declarations. Excludes Link and Doctype relation fields from the selection set.
+Build a GraphQL connection query to fetch a list of records. Only declares variables ($limit, $offset, $orderBy) that are actually used in the query, avoiding GraphQL spec §5.8.3 violations from unused variable declarations. Excludes Link relation fields and Display fields from the selection set.
 
 **Signature:**
 
@@ -363,7 +363,7 @@ declare function mergeNestedResults(params: MergeNestedResultsParams): Record<st
 
 ### queryableFieldNames
 
-Filter fields to only those directly queryable as scalars, excluding Link and Doctype relation fields that require GraphQL sub-selections.
+Filter fields to only those directly queryable as scalars, excluding Link relation fields and Display fields that have no backing DB column.
 
 **Signature:**
 
@@ -723,7 +723,7 @@ export const builtinHandlers: Record<string, ActionHandler>
 
 ### RELATION_FIELDTYPES
 
-Fieldtypes that map to GraphQL object/connection types and require sub-selections. These fields are excluded from generated query field selections.
+Fieldtypes excluded from the generated scalar query selection set. - `'Link'`: maps to a GraphQL object/connection type — requires a sub-selection - `'Display'`: display-only composite component with no backing DB column
 
 **Type:**
 

--- a/docs/reference/stonecrop.md
+++ b/docs/reference/stonecrop.md
@@ -1780,14 +1780,14 @@ getMeta(context: RouteContext): Promise<any>
 Get single record from server using the configured data client.
 
 ```typescript
-getRecord(doctype: Doctype, recordId: string): Promise<void>
+getRecord(doctype: string | Doctype, recordId: string): Promise<void>
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `Doctype` | The doctype |
+| doctype | `string \| Doctype` | The doctype slug string or Doctype object |
 | recordId | `string` | The record ID |
 
 #### getRecordById

--- a/graphql_middleware/README.md
+++ b/graphql_middleware/README.md
@@ -92,6 +92,16 @@ The middleware loads doctype definitions from JSON files. Each file defines a do
 
 The `links` object declares relationships used when `includeNested` is requested. The `workflow` object enables action dispatch.
 
+### Display-only fields
+
+Fields with `fieldtype: "Display"` are excluded from the auto-generated scalar query. Use this for composite UI components (e.g. a canvas visualisation) that have no backing database column:
+
+```json
+{ "fieldname": "planner", "fieldtype": "Display", "component": "Planner", "label": "Resource Planner" }
+```
+
+All other non-`Link` fieldtypes are assumed to map to a scalar DB column and are included in the query.
+
 ## Actions
 
 Actions are custom logic triggered by the client. Register handlers with `registerHandler`:

--- a/graphql_middleware/api.md
+++ b/graphql_middleware/api.md
@@ -24,7 +24,7 @@ import { ValidationError } from '@stonecrop/graphql_middleware'
 
 ### buildListQuery
 
-Build a GraphQL connection query to fetch a list of records. Only declares variables ($limit, $offset, $orderBy) that are actually used in the query, avoiding GraphQL spec §5.8.3 violations from unused variable declarations. Excludes Link and Doctype relation fields from the selection set.
+Build a GraphQL connection query to fetch a list of records. Only declares variables ($limit, $offset, $orderBy) that are actually used in the query, avoiding GraphQL spec §5.8.3 violations from unused variable declarations. Excludes Link relation fields and Display fields from the selection set.
 
 **Signature:**
 
@@ -358,7 +358,7 @@ declare function mergeNestedResults(params: MergeNestedResultsParams): Record<st
 
 ### queryableFieldNames
 
-Filter fields to only those directly queryable as scalars, excluding Link and Doctype relation fields that require GraphQL sub-selections.
+Filter fields to only those directly queryable as scalars, excluding Link relation fields and Display fields that have no backing DB column.
 
 **Signature:**
 
@@ -718,7 +718,7 @@ export const builtinHandlers: Record<string, ActionHandler>
 
 ### RELATION_FIELDTYPES
 
-Fieldtypes that map to GraphQL object/connection types and require sub-selections. These fields are excluded from generated query field selections.
+Fieldtypes excluded from the generated scalar query selection set. - `'Link'`: maps to a GraphQL object/connection type — requires a sub-selection - `'Display'`: display-only composite component with no backing DB column
 
 **Type:**
 

--- a/graphql_middleware/eslint.config.js
+++ b/graphql_middleware/eslint.config.js
@@ -1,0 +1,57 @@
+// @ts-check
+import eslint from '@eslint/js'
+import { defineConfig } from 'eslint/config'
+import eslintConfigPrettier from 'eslint-config-prettier'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default defineConfig(
+	{
+		ignores: ['dist/**', 'temp/**', 'node_modules/**', 'coverage/**', '*.config.ts', 'tests/**', 'eslint.config.js'],
+	},
+
+	eslint.configs.recommended,
+	...tseslint.configs.recommendedTypeChecked,
+
+	{
+		files: ['**/*.ts', '**/*.tsx'],
+		languageOptions: {
+			ecmaVersion: 'latest',
+			sourceType: 'module',
+			globals: {
+				...globals.node,
+			},
+			parser: tseslint.parser,
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+		plugins: {
+			'@typescript-eslint': tseslint.plugin,
+		},
+		rules: {
+			'no-console': 'warn',
+			'prefer-promise-reject-errors': 'off',
+			quotes: ['warn', 'single', { avoidEscape: true }],
+			'@typescript-eslint/no-explicit-any': 'off',
+			'@typescript-eslint/no-unsafe-assignment': 'off',
+			'@typescript-eslint/no-unsafe-return': 'off',
+			// PostGraphile resolver step specs are `any`-typed by the grafast API
+			'@typescript-eslint/no-unsafe-member-access': 'off',
+			'@typescript-eslint/no-unsafe-argument': 'off',
+			'@typescript-eslint/no-unsafe-call': 'off',
+			// ActionHandler interface requires async signatures even for sync implementations
+			'@typescript-eslint/require-await': 'off',
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+				},
+			],
+		},
+	},
+
+	eslintConfigPrettier
+)

--- a/graphql_middleware/package.json
+++ b/graphql_middleware/package.json
@@ -18,6 +18,7 @@
 		"prepublishOnly": "heft build && vite build && rushx docs",
 		"build": "heft build && vite build && rushx docs",
 		"docs": "bash ../common/scripts/run-docs.sh graphql_middleware",
+		"lint": "eslint .",
 		"test": "vitest run --coverage.enabled false",
 		"test:watch": "vitest watch",
 		"test:coverage": "vitest run --coverage",
@@ -30,13 +31,18 @@
 		"postgraphile": "^5.0.1"
 	},
 	"devDependencies": {
+		"@eslint/js": "^10.0.1",
 		"@rushstack/heft": "^1.2.17",
 		"@types/node": "^24.12.4",
 		"@types/pluralize": "^0.0.33",
 		"@vitest/coverage-istanbul": "^4.1.5",
 		"@vitest/ui": "^4.1.5",
+		"eslint": "^10.3.0",
+		"eslint-config-prettier": "^10.1.8",
+		"globals": "^17.6.0",
 		"stonecrop-rig": "workspace:*",
 		"typescript": "^6.0.3",
+		"typescript-eslint": "^8.59.1",
 		"vite": "^7.3.2",
 		"vitest": "^4.1.5"
 	}

--- a/graphql_middleware/src/plugin/postgraphile.ts
+++ b/graphql_middleware/src/plugin/postgraphile.ts
@@ -5,7 +5,7 @@ import { GraphileConfig } from 'postgraphile/graphile-build'
 import { extendSchema, gql } from 'postgraphile/utils'
 import pluralize from 'pluralize'
 
-import { getHandler, registerHandler } from '../registry/actions'
+import { getHandler } from '../registry/actions'
 import { getMeta, getAllMeta } from '../registry/doctypes'
 import type {
 	ActionContext,
@@ -249,7 +249,7 @@ export const createStonecropPlugin = (options: StonecropPluginOptions): Graphile
 												reverseConnectionName
 											)
 											const result = await options.executor.query(query, {
-												[recordArgName(meta.tableName!)]: spec.id,
+												[recordArgName(meta.tableName)]: spec.id,
 											})
 
 											let data = extractSingleResult({ result, meta, recordFieldName })
@@ -491,15 +491,16 @@ function isManyCardinality(cardinality: string): boolean {
 const DEFAULT_SYNC_LIMIT = 50
 
 /**
- * Fieldtypes that map to GraphQL object/connection types and require sub-selections.
- * These fields are excluded from generated query field selections.
+ * Fieldtypes excluded from the generated scalar query selection set.
+ * - `'Link'`: maps to a GraphQL object/connection type — requires a sub-selection
+ * - `'Display'`: display-only composite component with no backing DB column
  * @public
  */
-const RELATION_FIELDTYPES = new Set(['Link'])
+const RELATION_FIELDTYPES = new Set(['Link', 'Display'])
 
 /**
- * Filter fields to only those directly queryable as scalars, excluding Link and Doctype
- * relation fields that require GraphQL sub-selections.
+ * Filter fields to only those directly queryable as scalars, excluding Link relation
+ * fields and Display fields that have no backing DB column.
  * @public
  */
 function queryableFieldNames(meta: DoctypeMeta): string {
@@ -566,8 +567,7 @@ function buildNestedSelections(params: BuildNestedSelectionsParams): string {
 		if (!targetMeta) continue
 
 		const alreadySeen = seen.has(link.target)
-		if (alreadySeen) {
-		} else {
+		if (!alreadySeen) {
 			seen.add(link.target)
 		}
 		const scalarFields = queryableFieldNames(targetMeta)
@@ -679,7 +679,7 @@ function buildRecordQuery(
  * Build a GraphQL connection query to fetch a list of records.
  * Only declares variables ($limit, $offset, $orderBy) that are actually used in the query,
  * avoiding GraphQL spec §5.8.3 violations from unused variable declarations.
- * Excludes Link and Doctype relation fields from the selection set.
+ * Excludes Link relation fields and Display fields from the selection set.
  * @public
  */
 function buildListQuery(

--- a/graphql_middleware/src/registry/actions.ts
+++ b/graphql_middleware/src/registry/actions.ts
@@ -1,5 +1,5 @@
-import type { DoctypeMeta, FieldMeta } from '@stonecrop/schema'
-import type { ActionHandler, ActionContext } from '../types'
+import type { FieldMeta } from '@stonecrop/schema'
+import type { ActionHandler } from '../types'
 
 const handlerRegistry: Map<string, ActionHandler> = new Map()
 
@@ -111,7 +111,7 @@ const validateFieldTypes: ActionHandler = async (args, context) => {
  * Validate a single field value against its expected type
  */
 function validateFieldValue(field: FieldMeta, value: unknown): string | null {
-	const { fieldname, fieldtype, cardinality } = field
+	const { fieldname, fieldtype } = field
 
 	switch (fieldtype) {
 		case 'Int':

--- a/graphql_middleware/tests/queries.test.ts
+++ b/graphql_middleware/tests/queries.test.ts
@@ -96,6 +96,10 @@ describe('RELATION_FIELDTYPES', () => {
 		expect(RELATION_FIELDTYPES.has('Doctype')).toBe(false)
 	})
 
+	it('contains Display', () => {
+		expect(RELATION_FIELDTYPES.has('Display')).toBe(true)
+	})
+
 	it('does not contain scalar types', () => {
 		expect(RELATION_FIELDTYPES.has('Data')).toBe(false)
 		expect(RELATION_FIELDTYPES.has('Int')).toBe(false)
@@ -119,6 +123,22 @@ describe('queryableFieldNames', () => {
 		expect(names).toContain('rating')
 		expect(names).not.toContain('userByCreatedBy')
 		expect(names).not.toContain('recipeIngredientsByRecipeId')
+	})
+
+	it('excludes Display fields from scalar selection', () => {
+		const meta: DoctypeMeta = {
+			name: 'Plan',
+			tableName: 'plan',
+			fields: [
+				{ fieldname: 'id', fieldtype: 'Data', label: 'ID' },
+				{ fieldname: 'name', fieldtype: 'Data', label: 'Name' },
+				{ fieldname: 'planner', fieldtype: 'Display', component: 'Planner', label: 'Resource Planner' },
+			],
+		}
+		const names = queryableFieldNames(meta)
+		expect(names).toContain('id')
+		expect(names).toContain('name')
+		expect(names).not.toContain('planner')
 	})
 })
 

--- a/stonecrop/api.md
+++ b/stonecrop/api.md
@@ -1775,14 +1775,14 @@ getMeta(context: RouteContext): Promise<any>
 Get single record from server using the configured data client.
 
 ```typescript
-getRecord(doctype: Doctype, recordId: string): Promise<void>
+getRecord(doctype: string | Doctype, recordId: string): Promise<void>
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| doctype | `Doctype` | The doctype |
+| doctype | `string \| Doctype` | The doctype slug string or Doctype object |
 | recordId | `string` | The record ID |
 
 #### getRecordById

--- a/stonecrop/src/stonecrop.ts
+++ b/stonecrop/src/stonecrop.ts
@@ -378,11 +378,12 @@ export class Stonecrop {
 
 	/**
 	 * Get single record from server using the configured data client.
-	 * @param doctype - The doctype
+	 * @param doctype - The doctype slug string or Doctype object
 	 * @param recordId - The record ID
 	 * @throws Error if no data client has been configured
+	 * @throws Error if a slug string is given and no matching doctype is found in the registry
 	 */
-	async getRecord(doctype: Doctype, recordId: string): Promise<void> {
+	async getRecord(doctype: string | Doctype, recordId: string): Promise<void> {
 		if (!this._client) {
 			throw new Error(
 				'No data client configured. Call setClient() with a DataClient implementation ' +
@@ -390,10 +391,15 @@ export class Stonecrop {
 			)
 		}
 
-		const record = await this._client.getRecord(doctype, recordId)
+		const resolved = typeof doctype === 'string' ? this.registry.getDoctype(doctype) : doctype
+		if (!resolved) {
+			throw new Error(`Doctype not found: ${typeof doctype === 'string' ? doctype : doctype.slug}`)
+		}
+
+		const record = await this._client.getRecord(resolved, recordId)
 
 		if (record) {
-			this.addRecord(doctype, recordId, record)
+			this.addRecord(resolved, recordId, record)
 		}
 	}
 


### PR DESCRIPTION
- AForm wouldn't correctly apply the `width` property set for a field in a doctype schema.
- Desktop now fetches record details whenever a record page is navigated to (previously required visiting a table view to populate the HST)
- GraphQL middleware would try to connect a display-only field in a doctype schema (like the Planner in FAB) and add it to the query. New way of defining such fields is to set the `fieldtype: "Display"` property.
- AFormLink wouldn't process existing db values when a table or form view was loaded with it.