### PR TITLE
[examples] update desktop example to use DataClient interface

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       '@stonecrop/node-editor':
         specifier: workspace:*
         version: link:../node_editor
+      '@stonecrop/schema':
+        specifier: workspace:*
+        version: link:../schema
       '@stonecrop/stonecrop':
         specifier: workspace:*
         version: link:../stonecrop

--- a/examples/desktop/client.ts
+++ b/examples/desktop/client.ts
@@ -1,0 +1,49 @@
+import type {
+	DataClient,
+	DoctypeContext,
+	DoctypeMeta,
+	DoctypeRef,
+	GetRecordOptions,
+	GetRecordResult,
+	GetRecordsOptions,
+} from '@stonecrop/schema'
+
+export class RestDataClient implements DataClient {
+	async getMeta(context: DoctypeContext): Promise<DoctypeMeta | null> {
+		const route = context.recordId ? `/${context.doctype}/${context.recordId}` : `/${context.doctype}`
+		const response = await fetch(`/api/meta?route=${encodeURIComponent(route)}`)
+		if (!response.ok) return null
+		return response.json() as Promise<DoctypeMeta>
+	}
+
+	async getRecord(doctype: DoctypeRef, recordId: string, _options?: GetRecordOptions): Promise<GetRecordResult> {
+		const response = await fetch(`/api/${doctype.slug}/${recordId}`)
+		if (!response.ok) return { record: null }
+		const data = (await response.json()) as Record<string, unknown>
+		return { record: data }
+	}
+
+	async getRecords(doctype: DoctypeRef, _options?: GetRecordsOptions): Promise<Record<string, unknown>[]> {
+		const response = await fetch(`/api/${doctype.slug}`)
+		if (!response.ok) return []
+		return response.json() as Promise<Record<string, unknown>[]>
+	}
+
+	async runAction(
+		doctype: DoctypeRef,
+		action: string,
+		args?: unknown[]
+	): Promise<{ success: boolean; data: unknown; error: string | null }> {
+		const [recordId, data] = args ?? []
+		if (!recordId) return { success: false, data: null, error: 'recordId required' }
+
+		const response = await fetch(`/api/${doctype.slug}/${recordId as string}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action, ...(data as Record<string, unknown>) }),
+		})
+
+		if (!response.ok) return { success: false, data: null, error: response.statusText }
+		return response.json() as Promise<{ success: boolean; data: unknown; error: string | null }>
+	}
+}

--- a/examples/desktop/components/View.vue
+++ b/examples/desktop/components/View.vue
@@ -3,6 +3,7 @@
 		<Desktop
 			:available-doctypes="availableDoctypes"
 			:show-debug="showDebug"
+			:confirm-fn="confirmFn"
 			record-id-field="rowId"
 			@action="handleDesktopAction"
 			@navigate="handleDesktopNavigate"
@@ -62,9 +63,8 @@ function toggleOperationLog() {
 	showOperationLog.value = !showOperationLog.value
 }
 
-/** Pretend this is `await $fetch(...)` or `StonecropClient.runAction(...)`. */
-function simulateServerCall(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms))
+function confirmFn(message: string): boolean {
+	return window.confirm(message)
 }
 
 /**
@@ -73,8 +73,8 @@ function simulateServerCall(ms: number): Promise<void> {
  * Pattern:
  *   1. Sync any changed field values into HST.
  *   2. Fire the FSM transition (triggers registerTransitionAction side effects).
- *   3. Make the simulated server call — in a real app, replace with $fetch /
- *      StonecropClient.runAction and sync the response back via addRecord().
+ *   3. Dispatch through DataClient (real REST call via RestDataClient.runAction).
+ *   4. Sync the result back into HST.
  */
 async function handleDesktopAction(payload: ActionEventPayload) {
 	if (!stonecrop.value) return
@@ -90,23 +90,31 @@ async function handleDesktopAction(payload: ActionEventPayload) {
 			}
 		}
 		// 2. Trigger the FSM transition — fires registerTransitionAction side effects
-		await existing.triggerTransition(payload.name, {
-			fsmContext: payload.data,
-		})
+		await existing.triggerTransition(payload.name, { fsmContext: payload.data })
 	}
 
-	// 3. Simulated server call — owns persistence and response sync
+	// 3. Dispatch through DataClient
+	const doctype = stonecrop.value.registry.getDoctype(payload.doctype)
+	if (!doctype) return
+
+	const result = await stonecrop.value.dispatchAction(doctype, payload.name, [payload.recordId, payload.data])
+
+	if (!result.success) {
+		addNotification(`${payload.name} failed: ${result.error ?? 'unknown error'}`, 'error')
+		return
+	}
+
+	// 4. Sync response back into HST
 	switch (payload.name) {
-		case 'SAVE':
-			addNotification(`💾 Saving ${payload.doctype} record ${payload.recordId}...`, 'info')
-			await simulateServerCall(500)
-			addNotification(`✅ ${payload.doctype} record ${payload.recordId} saved successfully!`, 'success')
+		case 'SAVE': {
+			const saved = result.data as Record<string, unknown> | null
+			if (saved) stonecrop.value.addRecord(payload.doctype, payload.recordId, saved)
+			addNotification(`${payload.doctype} record ${payload.recordId} saved`, 'success')
 			break
+		}
 		case 'DELETE':
-			addNotification(`🗑️ Deleting ${payload.doctype} record ${payload.recordId}...`, 'warning')
-			await simulateServerCall(500)
 			stonecrop.value.removeRecord(payload.doctype, payload.recordId)
-			addNotification(`🗑️ ${payload.doctype} record ${payload.recordId} deleted`, 'info')
+			addNotification(`${payload.doctype} record ${payload.recordId} deleted`, 'info')
 			break
 	}
 }
@@ -126,26 +134,27 @@ function handleRecordOpen(payload: RecordOpenEventPayload) {
 
 /**
  * Handle load-records event - Desktop needs records for a list view.
- * In a real app, this would fetch from StonecropClient or your API.
+ * Desktop has no self-fetch for list views, so the host must populate HST here.
  */
-function handleLoadRecords(payload: LoadRecordsEventPayload) {
-	// eslint-disable-next-line no-console
-	console.debug('[example] load-records', payload)
-	// Example: fetch and populate HST
-	// const records = await stonecropClient.getRecords(payload.doctype)
-	// stonecrop.value.addRecords(payload.doctype, records)
+async function handleLoadRecords(payload: LoadRecordsEventPayload) {
+	if (!stonecrop.value) return
+	try {
+		const doctype = stonecrop.value.registry.getDoctype(payload.doctype)
+		if (doctype) await stonecrop.value.getRecords(doctype)
+	} catch (error) {
+		addNotification(`Failed to load ${payload.doctype} records`, 'error')
+		// eslint-disable-next-line no-console
+		console.error('[example] load-records failed', error)
+	}
 }
 
 /**
- * Handle load-record event - Desktop needs a single record for a form view.
- * In a real app, this would fetch from StonecropClient or your API.
+ * Handle load-record event - Desktop already self-fetches missing records when a
+ * client is configured (see Desktop.vue loadRecordData). This handler is reserved
+ * for host-side side effects (analytics, breadcrumb prefetch, etc.).
  */
-function handleLoadRecord(payload: LoadRecordEventPayload) {
-	// eslint-disable-next-line no-console
-	console.debug('[example] load-record', payload)
-	// Example: fetch and populate HST
-	// const record = await stonecropClient.getRecord(payload.doctype, payload.recordId)
-	// stonecrop.value.addRecord(payload.doctype, payload.recordId, record)
+function handleLoadRecord(_payload: LoadRecordEventPayload) {
+	// no-op — Desktop handles the fetch via its internal loadRecordData()
 }
 </script>
 

--- a/examples/desktop/index.ts
+++ b/examples/desktop/index.ts
@@ -15,6 +15,7 @@ import StonecropPlugin, {
 } from '@stonecrop/stonecrop'
 
 import App from './App.vue'
+import { RestDataClient } from './client'
 import router, { setupRouterContext } from './router'
 import { makeServer } from './server'
 
@@ -53,6 +54,7 @@ app.use(pinia)
 app.use(StonecropPlugin, {
 	router,
 	getMeta,
+	client: new RestDataClient(),
 	autoInitializeRouter: true,
 	onRouterInitialized: async (registry: Registry, stonecrop: Stonecrop) => {
 		// Setup router context with the provided instances

--- a/examples/desktop/router.ts
+++ b/examples/desktop/router.ts
@@ -24,93 +24,24 @@ export async function setupRouterContext(registry: Registry, stonecrop: Stonecro
 }
 
 /**
- * Setup doctype metadata and load all records for the doctype
+ * Setup doctype metadata only. Data hydration is handled by Desktop's load-records / load-record events.
  */
-async function setupDoctypeData(doctype: string, actualDoctype?: string, routePath?: string): Promise<void> {
-	if (!scopedRegistry || !scopedStonecrop) {
-		// Scoped Stonecrop references not available during route setup
-		return
-	}
+async function setupDoctypeMeta(actualDoctype: string, routePath: string): Promise<void> {
+	if (!scopedRegistry) return
 
 	try {
-		const targetDoctype = actualDoctype || doctype
-
-		// Get doctype metadata if not already loaded
-		if (!scopedRegistry.registry[targetDoctype]) {
-			// Create RouteContext for getMeta call
-			const defaultPath = routePath || `/${doctype}`
+		if (!scopedRegistry.registry[actualDoctype]) {
 			const routeContext = {
-				path: defaultPath,
-				segments: defaultPath.split('/').filter(s => s.length > 0),
+				path: routePath,
+				segments: routePath.split('/').filter((s: string) => s.length > 0),
 			}
-
 			const doctypeMeta = await scopedRegistry.getMeta?.(routeContext)
 			if (doctypeMeta) {
 				scopedRegistry.addDoctype(doctypeMeta)
 			}
 		}
-
-		// Load all records for this doctype into HST
-		const response = await fetch(`/api/${doctype}`)
-		if (response.ok) {
-			const records = await response.json()
-
-			// Clear existing records and add new ones using actual doctype
-			scopedStonecrop.clearRecords(targetDoctype)
-
-			if (Array.isArray(records)) {
-				records.forEach((record: any) => {
-					if (record.id) {
-						scopedStonecrop.addRecord(targetDoctype, record.id, record)
-					}
-				})
-			}
-		}
 	} catch (error) {
-		console.error(`Failed to setup doctype data for ${doctype}:`, error)
-	}
-}
-
-/**
- * Setup specific record data and set as current
- */
-async function setupRecordData(doctype: string, recordId: string, actualDoctype?: string): Promise<void> {
-	if (!scopedRegistry || !scopedStonecrop) {
-		// Scoped Stonecrop references not available during route setup
-		return
-	}
-
-	try {
-		const targetDoctype = actualDoctype || doctype
-
-		// Get form doctype metadata if not already loaded
-		if (!scopedRegistry.registry[targetDoctype]) {
-			// Create RouteContext for getMeta call
-			const route = `/${doctype}/${recordId}`
-			const routeContext = {
-				path: route,
-				segments: route.split('/').filter(s => s.length > 0),
-			}
-
-			const doctypeMeta = await scopedRegistry.getMeta?.(routeContext)
-			if (doctypeMeta) {
-				scopedRegistry.addDoctype(doctypeMeta)
-			}
-		}
-
-		// Check if record already exists in HST
-		const existingRecord = scopedStonecrop.getRecordById(targetDoctype, recordId)
-
-		if (!existingRecord && !recordId.startsWith('new-')) {
-			// Fetch individual record if not in store and not a new record
-			const response = await fetch(`/api/${doctype}/${recordId}`)
-			if (response.ok) {
-				const record = await response.json()
-				scopedStonecrop.addRecord(targetDoctype, recordId, record)
-			}
-		}
-	} catch (error) {
-		console.error(`Failed to setup record data for ${doctype}/${recordId}:`, error)
+		console.error(`Failed to setup doctype meta for ${actualDoctype}:`, error)
 	}
 }
 
@@ -189,7 +120,7 @@ async function registerDoctypeRoutes(doctype: string): Promise<boolean> {
 				try {
 					const routeDoctype = to.meta.doctype as string
 					const actualDoctype = to.meta.actualDoctype as string
-					await setupDoctypeData(routeDoctype, actualDoctype, to.path)
+					await setupDoctypeMeta(actualDoctype, to.path)
 					if (routeDoctype === 'todo') {
 						await setupLinkedData('category')
 					}
@@ -215,8 +146,7 @@ async function registerDoctypeRoutes(doctype: string): Promise<boolean> {
 				try {
 					const routeDoctype = to.meta.doctype as string
 					const actualDoctype = to.meta.actualDoctype as string
-					const recordId = to.params.recordId as string
-					await setupRecordData(routeDoctype, recordId, actualDoctype)
+					await setupDoctypeMeta(actualDoctype, to.path)
 					if (routeDoctype === 'todo') {
 						await setupLinkedData('category')
 					}

--- a/examples/desktop/server.ts
+++ b/examples/desktop/server.ts
@@ -85,7 +85,7 @@ export function makeServer() {
 						{ fieldname: 'first_name', label: 'First Name', fieldtype: 'Data' },
 						{ fieldname: 'last_name', label: 'Last Name', fieldtype: 'Data' },
 						{ fieldname: 'phone', label: 'Phone', fieldtype: 'Phone' },
-						{ fieldname: 'category_id', label: 'Category', fieldtype: 'Link', doctype: 'category' },
+						{ fieldname: 'category_id', label: 'Category', fieldtype: 'Link', options: 'category' },
 					] as MutableDoctype['schema'],
 					workflow: {
 						id: 'todoList',
@@ -162,7 +162,7 @@ export function makeServer() {
 							fieldtype: 'Link',
 							component: 'AFormLink',
 							label: 'Category',
-							doctype: 'category',
+							options: 'category',
 						},
 					] as MutableDoctype['schema'],
 					workflow: {
@@ -410,6 +410,14 @@ export function makeServer() {
 				return records ? records.find(id) || {} : {}
 			})
 
+			// category-form slug also reads from the categories collection
+			this.get('/api/category-form/:id', (schema, request) => {
+				const id = request.params.id
+				// @ts-expect-error mismatch between mirage types
+				const records = schema.db['categories'] as DbCollection
+				return records ? records.find(id) || {} : {}
+			})
+
 			// Data endpoints
 			this.get('/api/:doctype', (schema, request) => {
 				const doctype = request.params.doctype
@@ -451,6 +459,38 @@ export function makeServer() {
 				}
 
 				return {}
+			})
+
+			// Action endpoints (SAVE / DELETE)
+			this.post('/api/:doctype/:id', (schema, request) => {
+				const doctype = request.params.doctype
+				const id = request.params.id
+				const body = JSON.parse(request.requestBody) as Record<string, unknown>
+				const action = body.action as string
+
+				let actualDoctype = doctype
+				if (doctype === 'todo') actualDoctype = 'todo-form'
+				else if (doctype === 'issue') actualDoctype = 'issue-form'
+
+				// category and category-form both write to the categories collection
+				const dataKey =
+					actualDoctype === 'category' || actualDoctype === 'category-form' ? 'categories' : `${actualDoctype}s`
+				// @ts-expect-error mismatch between mirage types
+				const records = schema.db[dataKey] as DbCollection
+				if (!records) return { success: false, data: null, error: 'Collection not found' }
+
+				if (action === 'DELETE') {
+					records.remove(id)
+					return { success: true, data: null, error: null }
+				}
+
+				if (action === 'SAVE') {
+					const { action: _action, ...attrs } = body
+					records.update(id, attrs)
+					return { success: true, data: records.find(id) || null, error: null }
+				}
+
+				return { success: false, data: null, error: `Unknown action: ${action}` }
 			})
 
 			// allow other same-domain and external requests to passthrough normally

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,6 +21,7 @@
 	"dependencies": {
 		"@stonecrop/aform": "workspace:*",
 		"@stonecrop/atable": "workspace:*",
+		"@stonecrop/schema": "workspace:*",
 		"@stonecrop/beam": "workspace:*",
 		"@stonecrop/code-editor": "workspace:*",
 		"@stonecrop/desktop": "workspace:*",


### PR DESCRIPTION
Updates the desktop example to use the Stonecrop framework via the generic DataClient interface. This should make it easier to iterate on new features without relying on full user apps.