### PR TITLE
Aform longtext styling

### DIFF
--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -151,6 +151,7 @@ const childModels = computed(() => childModelsCache.value)
 /* global styles for aform */
 .aform input {
 	font-family: var(--sc-font-family);
+	border: none;
 }
 .aform_form-element {
 	padding: 0;
@@ -218,13 +219,16 @@ const childModels = computed(() => childModelsCache.value)
 	line-height: 0;
 	transform: translateY(-50%);
 }
-.aform_input-field:disabled {
+.aform_input-field:disabled,
+.aform_checkbox-container:has(.aform_checkbox:disabled) {
 	background: var(--sc-input-field-disabled-background);
 }
-.aform_input-field:disabled + .aform_field-label {
+.aform_input-field:disabled + .aform_field-label,
+.aform_checkbox-container:has(.aform_checkbox:disabled) + .aform_field-label {
 	background: linear-gradient(var(--sc-form-background) 50%, var(--sc-input-field-disabled-background) 50%);
 }
-.aform_input-field:disabled ~ p.aform_error {
+.aform_input-field:disabled ~ p.aform_error,
+.aform_checkbox-container:has(.aform_checkbox:disabled) ~ p.aform_error {
 	background: linear-gradient(var(--sc-form-background) 50%, var(--sc-input-field-disabled-background) 50%);
 }
 .aform_field-label::after {

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -160,7 +160,7 @@ const childModels = computed(() => childModelsCache.value)
 	box-sizing: border-box;
 	flex-grow: 1;
 	min-width: 20ch;
-	margin-bottom: 1rem;
+	/* margin-bottom: 1rem; */
 }
 .aform__grid--full {
 	flex-basis: 100%;

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -149,6 +149,9 @@ const childModels = computed(() => childModelsCache.value)
 
 <style>
 /* global styles for aform */
+.aform input {
+	font-family: var(--sc-font-family);
+}
 .aform_form-element {
 	padding: 0;
 	margin: 0;
@@ -175,6 +178,7 @@ const childModels = computed(() => childModelsCache.value)
 	position: relative;
 	color: var(--sc-cell-text-color);
 	background: var(--sc-input-field-background);
+	font-family: var(--sc-font-family);
 }
 .aform_input-field:focus {
 	outline: 1px solid var(--sc-input-active-border-color);

--- a/aform/src/components/form/ACheckbox.vue
+++ b/aform/src/components/form/ACheckbox.vue
@@ -1,11 +1,10 @@
 <template>
-	<div class="aform_form-element">
+	<div class="aform_form-element" :style="{ width: getElementwidth }">
 		<template v-if="mode === 'display'">
 			<label class="aform_field-label">{{ label }}</label>
 			<span class="aform_display-value">{{ checkbox ? '✓' : '✗' }}</span>
 		</template>
 		<template v-else>
-			<label class="aform_field-label" :for="uuid">{{ label }}</label>
 			<span class="aform_checkbox-container aform_input-field">
 				<input
 					:id="uuid"
@@ -15,21 +14,39 @@
 					:disabled="mode === 'read'"
 					:required="required" />
 			</span>
+			<label ref="label" class="aform_field-label" :for="uuid">{{ label }}</label>
 			<p v-show="validation.errorMessage" class="aform_error" v-html="validation.errorMessage"></p>
 		</template>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { InputHTMLAttributes } from 'vue'
+import { InputHTMLAttributes, ref, onMounted, useTemplateRef, computed } from 'vue'
 
 import { ComponentProps } from '../../types'
 
 const { label, required, mode, uuid, validation = { errorMessage: '&nbsp;' } } = defineProps<ComponentProps>()
 const checkbox = defineModel<InputHTMLAttributes['checked']>()
+
+const totalWidth = ref(0)
+const labelRef = useTemplateRef('label')
+const paddingAmount = 20
+
+onMounted(() => {
+	totalWidth.value = labelRef.value.offsetWidth
+	console.log(totalWidth.value)
+})
+
+const getElementwidth = computed(() => {
+	return totalWidth.value + paddingAmount + 'px'
+})
 </script>
 
 <style scoped>
+.aform_form-element {
+	min-width: auto;
+	flex-grow: 0;
+}
 .aform_checkbox {
 	cursor: pointer;
 	width: auto;
@@ -46,10 +63,14 @@ const checkbox = defineModel<InputHTMLAttributes['checked']>()
 	width: 100%;
 	display: inline-block;
 	text-align: left;
+	height: 100%;
 }
 
 .aform_checkbox-container input {
 	width: auto;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
 }
 
 .aform_checkbox-container:hover + .aform_field-label {

--- a/aform/src/components/form/ADropdown.vue
+++ b/aform/src/components/form/ADropdown.vue
@@ -170,6 +170,7 @@ input {
 	margin: calc(1.15rem / 2) 0 0 0;
 	min-height: 1.15rem;
 	border-radius: 0.25rem;
+	font-family: var(--sc-font-family);
 }
 
 input:focus {

--- a/aform/src/components/form/ATextboxInput.vue
+++ b/aform/src/components/form/ATextboxInput.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-if="!hidden" class="a-long-text" :class="{ 'is-read-only': isReadOnly }">
-		<label v-if="label" :for="fieldname" class="a-long-text__label">
+		<label v-if="label" :for="fieldname" class="a-long-text__label aform_field-label">
 			{{ label }}<span v-if="required" class="a-long-text__required" aria-hidden="true">*</span>
 		</label>
 		<textarea
@@ -67,12 +67,14 @@ function onInput(event: Event) {
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-xs, 0.25rem);
+	width: 100%;
+	position: relative;
 }
 
-.a-long-text__label {
+/* .a-long-text__label {
 	font-size: var(--font-size-sm, 0.875rem);
 	color: var(--color-text-secondary, #666);
-}
+} */
 
 .a-long-text__required {
 	color: var(--color-danger, #c00);

--- a/atable/src/components/AGanttCell.vue
+++ b/atable/src/components/AGanttCell.vue
@@ -138,17 +138,15 @@ const barStyle = computed((): StyleValue => {
 	}
 })
 
-const connectionDragStyle = computed(
-	(): StyleValue => ({
-		position: 'fixed',
-		top: 0,
-		left: 0,
-		width: '100vw',
-		height: '100vh',
-		pointerEvents: 'none',
-		zIndex: 1000,
-	})
-)
+const connectionDragStyle = computed((): StyleValue => ({
+	position: 'fixed',
+	top: 0,
+	left: 0,
+	width: '100vw',
+	height: '100vh',
+	pointerEvents: 'none',
+	zIndex: 1000,
+}))
 
 // Drag setup data
 const dragStartData = ref({ startX: 0, startPos: 0 })

--- a/common/autoinstallers/rush-prettier/pnpm-lock.yaml
+++ b/common/autoinstallers/rush-prettier/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       prettier:
         specifier: ^3.8.3
-        version: 3.8.3
+        version: 3.9.3
       pretty-quick:
         specifier: ^4.2.2
-        version: 4.2.2(prettier@3.8.3)
+        version: 4.2.2(prettier@3.9.3)
 
 packages:
 
@@ -36,8 +36,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.3:
+    resolution: {integrity: sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -66,16 +66,16 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.3: {}
 
-  pretty-quick@4.2.2(prettier@3.8.3):
+  pretty-quick@4.2.2(prettier@3.9.3):
     dependencies:
       '@pkgr/core': 0.2.10
       ignore: 7.0.5
       mri: 1.2.0
       picocolors: 1.1.1
       picomatch: 4.0.4
-      prettier: 3.8.3
+      prettier: 3.9.3
       tinyexec: 0.3.2
       tslib: 2.8.1
 

--- a/common/changes/@stonecrop/aform/aform-longtext-styling_2026-06-29-18-06.json
+++ b/common/changes/@stonecrop/aform/aform-longtext-styling_2026-06-29-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/aform",
+      "comment": "updated aform to use Arimo font, fixed checkbox input styling issues, added styling to textarea component",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/aform"
+}

--- a/common/changes/@stonecrop/atable/aform-longtext-styling_2026-06-29-18-06.json
+++ b/common/changes/@stonecrop/atable/aform-longtext-styling_2026-06-29-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/atable",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/atable"
+}

--- a/common/changes/@stonecrop/schema/aform-longtext-styling_2026-06-29-18-06.json
+++ b/common/changes/@stonecrop/schema/aform-longtext-styling_2026-06-29-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/schema",
+      "comment": "add schema for mixed element story, adds textarea field in middle of form",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/schema"
+}

--- a/common/changes/@stonecrop/stonecrop/aform-longtext-styling_2026-06-29-18-06.json
+++ b/common/changes/@stonecrop/stonecrop/aform-longtext-styling_2026-06-29-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/stonecrop",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/stonecrop"
+}

--- a/common/changes/@stonecrop/themes/aform-longtext-styling_2026-06-29-18-06.json
+++ b/common/changes/@stonecrop/themes/aform-longtext-styling_2026-06-29-18-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@stonecrop/themes",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@stonecrop/themes"
+}

--- a/docs/reference/aform.md
+++ b/docs/reference/aform.md
@@ -113,20 +113,20 @@ Vue component exported from @stonecrop/aform.
 import { AFormLink } from '@stonecrop/aform'
 ```
 
-### ATextboxInput
-
-Vue component exported from @stonecrop/aform.
-
-```typescript
-import { ATextboxInput } from '@stonecrop/aform'
-```
-
 ### ANumericInput
 
 Vue component exported from @stonecrop/aform.
 
 ```typescript
 import { ANumericInput } from '@stonecrop/aform'
+```
+
+### ATextboxInput
+
+Vue component exported from @stonecrop/aform.
+
+```typescript
+import { ATextboxInput } from '@stonecrop/aform'
 ```
 
 ### ATextInput

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -829,7 +829,7 @@ The complete list of field types built into Stonecrop. User apps can use any str
 **Type:**
 
 ```typescript
-export const BUILTIN_FIELD_TYPES: readonly ["Data", "Text", "Int", "Float", "Decimal", "Check", "Date", "Time", "Datetime", "Duration", "DateRange", "JSON", "Code", "Link", "Attach", "Currency", "Quantity", "Select", "PrimaryKey", "Fieldset","LongText", "Display"]
+export const BUILTIN_FIELD_TYPES: readonly ["Data", "Text", "Int", "Float", "Decimal", "Check", "Date", "Time", "Datetime", "Duration", "DateRange", "JSON", "Code", "Link", "Attach", "Currency", "Quantity", "Select", "PrimaryKey", "TextBox", "Fieldset", "Display"]
 ```
 
 ### Cardinality

--- a/examples/aform/assets/mixed_form_schema.json
+++ b/examples/aform/assets/mixed_form_schema.json
@@ -1,0 +1,57 @@
+[
+	{
+		"fieldname": "first_name",
+		"fieldtype": "Data",
+		"component": "ATextInput",
+		"label": "First Name"
+	},
+	{
+		"fieldname": "last_name",
+		"fieldtype": "Data",
+		"component": "ATextInput",
+		"label": "Last Name"
+	},
+	{
+		"fieldname": "enabled",
+		"fieldtype": "Check",
+		"component": "ACheckbox",
+		"label": "Enabled"
+	},
+	{
+		"fieldname": "age",
+		"fieldtype": "Int",
+		"component": "ANumericInput",
+		"label": "Age"
+	},
+	{
+		"fieldname": "comments",
+		"fieldtype": "Data",
+		"component": "ATextboxInput",
+		"label": "Comments"
+	},
+	{
+		"fieldname": "date",
+		"fieldtype": "Date",
+		"component": "ATextInput",
+		"label": "Date"
+	},
+	{
+		"fieldname": "card",
+		"fieldtype": "Data",
+		"component": "ATextInput",
+		"label": "Card"
+	},
+	{
+		"fieldname": "phone",
+		"fieldtype": "Data",
+		"component": "ATextInput",
+		"label": "Phone",
+		"mask": "(locale) => { if (locale === 'en-US') { return '(###) ###-####' } else if (locale === 'en-IN') { return '####-######'} }"
+	},
+	{
+		"fieldname": "attach_file",
+		"fieldtype": "Attach",
+		"component": "AFileAttach",
+		"label": "Attach Files"
+	}
+]

--- a/examples/aform/form.story.vue
+++ b/examples/aform/form.story.vue
@@ -46,6 +46,9 @@
 		<Variant title="TextBox">
 			<AForm class="aform-main" :schema="textbox_schema" v-model:data="data" />
 		</Variant>
+		<Variant title="Mixed Element Form">
+			<AForm class="aform-main" :schema="mixed_form_schema" v-model:data="data" />
+		</Variant>
 	</Story>
 </template>
 
@@ -58,12 +61,14 @@ import basic_table_schema from './assets/basic_table_schema.json'
 import fieldset_table_schema from './assets/fieldset_table_schema.json'
 import hidden_field_schema_json from './assets/hidden_field_schema.json'
 import basic_textbox_schema from './assets/basic_textbox_schema.json'
+import mixed_form_schema from './assets/mixed_form_schema.json'
 const form_schema = ref(basic_form_schema)
 const fieldset_schema = ref(basic_fieldset_schema)
 const table_schema = ref(basic_table_schema)
 const fieldset_table_schema_ref = ref(fieldset_table_schema)
 const hidden_field_schema = ref(hidden_field_schema_json)
 const textbox_schema = ref(basic_textbox_schema)
+const mixed_schema = ref(mixed_form_schema)
 
 const data = ref({})
 const hidden_data = ref({

--- a/stonecrop/src/stores/operation-log.ts
+++ b/stonecrop/src/stores/operation-log.ts
@@ -156,15 +156,13 @@ export const useOperationLogStore = defineStore('hst-operation-log', () => {
 		return operations.value.length - 1 - currentIndex.value
 	})
 
-	const undoRedoState = computed(
-		(): UndoRedoState => ({
-			canUndo: canUndo.value,
-			canRedo: canRedo.value,
-			undoCount: undoCount.value,
-			redoCount: redoCount.value,
-			currentIndex: currentIndex.value,
-		})
-	)
+	const undoRedoState = computed((): UndoRedoState => ({
+		canUndo: canUndo.value,
+		canRedo: canRedo.value,
+		undoCount: undoCount.value,
+		redoCount: redoCount.value,
+		currentIndex: currentIndex.value,
+	}))
 
 	// Core Methods
 

--- a/themes/default/_variables.css
+++ b/themes/default/_variables.css
@@ -47,7 +47,7 @@
 
 	/* FONT */
 	--sc-font-size: 10px;
-	--sc-font-family: Arimo, Arial, sans-serif;
+	--sc-font-family: 'Arimo', Arial, sans-serif;
 	--sc-table-font-size: 16px;
 	--sc-atable-font-family: 'Arimo', sans-serif;
 


### PR DESCRIPTION
Updated styling for the AFormTextboxInput, fixed font issue with inputs not using Arimo (it was defaulting to browser default input styling), and made updates to the checkbox component so it now sizes correctly (label size +20px padding, instead of these massively wide checkbox containers). The checkbox field wasn't correctly styled when disabled, so I fixed that as well. 

I made the AFormTextboxInput a full-width form element, since it spans more than one line. This helps prevent weird layouts when a single-line input is next to a multiline box, as well as giving the user more room to enter information.

I also added a mixed-form-element schema to the stories to showcase the textarea element in the middle of the form with other inputs around it. 