### PR TITLE
[aform][atable] badge component

### DIFF
--- a/aform/api.md
+++ b/aform/api.md
@@ -4,6 +4,14 @@
 
 ## Vue Components
 
+### ABadge
+
+Vue component exported from @stonecrop/aform.
+
+```typescript
+import { ABadge } from '@stonecrop/aform'
+```
+
 ### ACheckbox
 
 Vue component exported from @stonecrop/aform.
@@ -174,6 +182,22 @@ import { Login } from '@stonecrop/aform'
 
 ## Functions
 
+### badgeInputAccentStyle
+
+CSS custom properties for input-accent styling on a native input.
+
+**Signature:**
+
+```typescript
+export declare function badgeInputAccentStyle(descriptor: BadgeDescriptor | undefined): Record<string, string> | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| descriptor | `BadgeDescriptor \| undefined` |  |
+
 ### deserializeFunction
 
 Deserializes a stringified function expression into a typed callable.
@@ -207,6 +231,25 @@ declare function install(app: App): void;
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | app | `App` | Vue app instance |
+
+### resolveFieldBadge
+
+Resolve a field value to a badge descriptor using format (if present) then options map.
+
+**Signature:**
+
+```typescript
+export declare function resolveFieldBadge(value: unknown, options: FieldOptions | undefined, format: string | BadgeFormatFn | undefined, context?: BadgeFormatContext): BadgeDescriptor | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | `unknown` |  |
+| options | `FieldOptions \| undefined` |  |
+| format | `string \| BadgeFormatFn \| undefined` |  |
+| context | `BadgeFormatContext` |  |
 
 ## Interfaces
 
@@ -470,6 +513,29 @@ Emitting is narrower — AFormLink always writes back an `AFormLinkValue`.
 
 ```typescript
 export type AFormLinkModelValue = AFormLinkValue | string | number;
+```
+
+### BadgeFormatContext
+
+Row context passed to badge `format` functions in form fields.
+
+**Definition:**
+
+```typescript
+export type BadgeFormatContext = {
+    record?: Record<string, unknown>;
+    row?: Record<string, unknown>;
+};
+```
+
+### BadgeFormatFn
+
+Badge-aware field `format` function signature.
+
+**Definition:**
+
+```typescript
+export type BadgeFormatFn = (value: unknown, context: BadgeFormatContext) => string | BadgeDescriptor;
 ```
 
 ### ComponentProps

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -106,10 +106,6 @@ const componentProps = (componentObj: ResolvedField) => {
 		propsToPass['rows'] = dataModel.value[componentObj.fieldname] || []
 	}
 
-	if (componentObj.kind === 'field') {
-		propsToPass['record'] = dataModel.value
-	}
-
 	return propsToPass
 }
 

--- a/aform/src/components/AForm.vue
+++ b/aform/src/components/AForm.vue
@@ -106,6 +106,10 @@ const componentProps = (componentObj: ResolvedField) => {
 		propsToPass['rows'] = dataModel.value[componentObj.fieldname] || []
 	}
 
+	if (componentObj.kind === 'field') {
+		propsToPass['record'] = dataModel.value
+	}
+
 	return propsToPass
 }
 

--- a/aform/src/components/form/ABadge.vue
+++ b/aform/src/components/form/ABadge.vue
@@ -9,7 +9,9 @@ import { computed, type CSSProperties } from 'vue'
 
 const props = defineProps<
 	Partial<BadgeDescriptor> & {
-		presentation: BadgePresentation
+		/** Defaults to `cell-fill`: every call site fully determines this, so omitting it should
+		 * degrade to the common case rather than rendering an unstyled badge. */
+		presentation?: BadgePresentation
 		/** Stored field value — used with `options` when `label` is omitted. */
 		value?: unknown
 		options?: FieldOptions
@@ -35,7 +37,11 @@ const activeVariant = computed((): BadgeVariant => resolved.value?.variant ?? pr
 
 const activeColor = computed(() => resolved.value?.color ?? props.color)
 
-const classes = computed(() => ['abadge', `abadge--${props.presentation}`, `abadge--${activeVariant.value}`])
+const classes = computed(() => [
+	'abadge',
+	`abadge--${props.presentation ?? 'cell-fill'}`,
+	`abadge--${activeVariant.value}`,
+])
 
 const styleVars = computed((): CSSProperties => {
 	const color = activeColor.value

--- a/aform/src/components/form/ABadge.vue
+++ b/aform/src/components/form/ABadge.vue
@@ -1,0 +1,129 @@
+<template>
+	<span v-if="displayLabel" :class="classes" :style="styleVars">{{ displayLabel }}</span>
+</template>
+
+<script setup lang="ts">
+import type { BadgeDescriptor, BadgePresentation, BadgeVariant, FieldOptions } from '@stonecrop/schema'
+import { lookupBadge } from '@stonecrop/schema'
+import { computed, type CSSProperties } from 'vue'
+
+const props = defineProps<
+	Partial<BadgeDescriptor> & {
+		presentation: BadgePresentation
+		/** Stored field value — used with `options` when `label` is omitted. */
+		value?: unknown
+		options?: FieldOptions
+	}
+>()
+
+const resolved = computed((): BadgeDescriptor | undefined => {
+	if (props.label?.trim()) {
+		return {
+			label: props.label.trim(),
+			variant: props.variant,
+			color: props.color,
+		}
+	}
+	if (props.value === null || props.value === undefined || props.value === '') return undefined
+	const key = typeof props.value === 'string' ? props.value : String(props.value)
+	return lookupBadge(props.options, key)
+})
+
+const displayLabel = computed(() => resolved.value?.label?.trim() ?? '')
+
+const activeVariant = computed((): BadgeVariant => resolved.value?.variant ?? props.variant ?? 'neutral')
+
+const activeColor = computed(() => resolved.value?.color ?? props.color)
+
+const classes = computed(() => ['abadge', `abadge--${props.presentation}`, `abadge--${activeVariant.value}`])
+
+const styleVars = computed((): CSSProperties => {
+	const color = activeColor.value
+	if (!color) return {}
+	return {
+		'--sc-badge-bg': color,
+		'--sc-badge-text': color,
+		'--sc-badge-accent': color,
+	} as CSSProperties
+})
+
+export type { BadgePresentation, BadgeVariant }
+</script>
+
+<style scoped>
+.abadge {
+	display: block;
+	box-sizing: border-box;
+	font: inherit;
+	line-height: inherit;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.abadge--cell-fill {
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	min-height: calc(var(--sc-atable-row-height, 1.5em) + 2 * var(--sc-atable-row-padding, 0.125rem));
+	line-height: calc(var(--sc-atable-row-height, 1.5em) + 2 * var(--sc-atable-row-padding, 0.125rem));
+	margin: 0;
+	padding: 0 0.5ch;
+	border-radius: 0;
+	text-align: inherit;
+	background: var(--sc-badge-bg);
+	color: var(--sc-badge-text);
+}
+
+.abadge--cell-fill.abadge--neutral {
+	--sc-badge-bg: var(--sc-badge-neutral-bg);
+	--sc-badge-text: var(--sc-badge-neutral-text);
+}
+
+.abadge--cell-fill.abadge--success {
+	--sc-badge-bg: var(--sc-badge-success-bg);
+	--sc-badge-text: var(--sc-badge-success-text);
+}
+
+.abadge--cell-fill.abadge--warning {
+	--sc-badge-bg: var(--sc-badge-warning-bg);
+	--sc-badge-text: var(--sc-badge-warning-text);
+}
+
+.abadge--cell-fill.abadge--danger {
+	--sc-badge-bg: var(--sc-badge-danger-bg);
+	--sc-badge-text: var(--sc-badge-danger-text);
+}
+
+.abadge--cell-fill.abadge--brand {
+	--sc-badge-bg: var(--sc-badge-brand-bg);
+	--sc-badge-text: var(--sc-badge-brand-text);
+}
+
+.abadge--input-accent {
+	background: var(--sc-input-field-background, #ffffff);
+	color: inherit;
+	border-left: 4px solid var(--sc-badge-accent);
+	padding-left: calc(1ch - 4px);
+}
+
+.abadge--input-accent.abadge--neutral {
+	--sc-badge-accent: var(--sc-badge-neutral-accent);
+}
+
+.abadge--input-accent.abadge--success {
+	--sc-badge-accent: var(--sc-badge-success-accent);
+}
+
+.abadge--input-accent.abadge--warning {
+	--sc-badge-accent: var(--sc-badge-warning-accent);
+}
+
+.abadge--input-accent.abadge--danger {
+	--sc-badge-accent: var(--sc-badge-danger-accent);
+}
+
+.abadge--input-accent.abadge--brand {
+	--sc-badge-accent: var(--sc-badge-brand-accent);
+}
+</style>

--- a/aform/src/components/form/ADropdown.vue
+++ b/aform/src/components/form/ADropdown.vue
@@ -1,50 +1,61 @@
 <template>
-	<div v-if="mode === 'display'" class="input-wrapper">
-		<span class="aform_display-value">{{ search ?? '' }}</span>
-		<label>{{ label }}</label>
-		<p v-show="errorText" class="aform_error" v-html="errorText"></p>
-	</div>
-	<div v-else v-on-click-outside="onClickOutside" class="autocomplete" :class="{ isOpen: dropdown.open }">
-		<div class="input-wrapper">
-			<input
-				v-model="search"
-				type="text"
-				:disabled="mode === 'read'"
-				@input="filter"
-				@focus="openDropdown"
-				@keydown.down="selectNextResult"
-				@keydown.up="selectPrevResult"
-				@keydown.enter="setCurrentResult"
-				@keydown.esc="onClickOutside"
-				@keydown.tab="onClickOutside" />
+	<div class="aform_form-element">
+		<template v-if="mode === 'display'">
+			<span v-if="badgeDescriptor" class="aform_display-value" :style="displayAccentStyle">{{
+				badgeDescriptor.label
+			}}</span>
+			<span v-else class="aform_display-value">{{ search ?? '' }}</span>
+			<label class="aform_field-label">{{ label }}</label>
+		</template>
+		<template v-else>
+			<div v-on-click-outside="onClickOutside" class="autocomplete" :class="{ isOpen: dropdown.open }">
+				<input
+					v-model="search"
+					type="text"
+					class="aform_input-field"
+					:disabled="mode === 'read'"
+					:style="inputAccentStyle"
+					@input="filter"
+					@focus="openDropdown"
+					@keydown.down="selectNextResult"
+					@keydown.up="selectPrevResult"
+					@keydown.enter="setCurrentResult"
+					@keydown.esc="onClickOutside"
+					@keydown.tab="onClickOutside" />
 
-			<ul v-show="dropdown.open" id="autocomplete-results" class="autocomplete-results">
-				<li v-if="dropdown.loading" class="loading autocomplete-result">Loading results...</li>
-				<li
-					v-for="(result, i) in dropdown.results"
-					v-else
-					:key="result"
-					class="autocomplete-result"
-					:class="{ 'is-active': i === dropdown.activeItemIndex }"
-					@click.stop="setResult(result)">
-					{{ result }}
-				</li>
-			</ul>
-			<label>{{ label }}</label>
-		</div>
-		<p v-show="errorText" class="aform_error" v-html="errorText"></p>
+				<ul v-show="dropdown.open" id="autocomplete-results" class="autocomplete-results">
+					<li v-if="dropdown.loading" class="loading autocomplete-result">Loading results...</li>
+					<li
+						v-for="(result, i) in dropdown.results"
+						v-else
+						:key="result"
+						class="autocomplete-result"
+						:class="{ 'is-active': i === dropdown.activeItemIndex }"
+						@click.stop="setResult(result)">
+						{{ result }}
+					</li>
+				</ul>
+				<label class="aform_field-label">{{ label }}</label>
+			</div>
+			<p v-show="errorText" class="aform_error" v-html="errorText"></p>
+		</template>
 	</div>
 </template>
 
 <script setup lang="ts">
+import type { FieldOptions } from '@stonecrop/schema'
+import { selectChoices } from '@stonecrop/schema'
 import { vOnClickOutside } from '@vueuse/components'
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 
 import type { ComponentProps } from '../../types'
+import { badgeInputAccentStyle, resolveFieldBadge } from '../../utils/badge'
 
 const {
 	label,
 	options = [],
+	format,
+	record,
 	isAsync = false,
 	filterFunction = undefined,
 	mode,
@@ -52,25 +63,41 @@ const {
 	validation = { errorMessage: '' },
 } = defineProps<
 	ComponentProps & {
-		options?: string[]
+		options?: FieldOptions
+		format?: string
+		record?: Record<string, unknown>
 		isAsync?: boolean
 		filterFunction?: (search: string) => string[] | Promise<string[]>
 	}
 >()
 
-// Dynamic trigger errors take precedence over a static schema errorMessage; empty means the slot hides.
+const choiceList = computed(() => selectChoices(options))
+
+const badgeDescriptor = computed(() => resolveFieldBadge(search.value, options, format, { record, row: record }))
+
+const inputAccentStyle = computed(() => badgeInputAccentStyle(badgeDescriptor.value))
+
+const displayAccentStyle = computed(() => badgeInputAccentStyle(badgeDescriptor.value))
+
 const errorText = computed(() => (errors?.length ? errors.join('; ') : (validation.errorMessage ?? '')))
 const search = defineModel<string>()
 
-// tracks the last explicitly-committed value so outside-click reverts instead of clears
 const committedValue = ref(search.value ?? '')
 
 const dropdown = reactive({
 	activeItemIndex: null as number | null,
 	open: false,
 	loading: false,
-	results: options,
+	results: [] as string[],
 })
+
+watch(
+	choiceList,
+	choices => {
+		dropdown.results = choices
+	},
+	{ immediate: true }
+)
 
 const onClickOutside = () => closeDropdown()
 
@@ -99,26 +126,25 @@ const setResult = (result: string) => {
 }
 
 const openDropdown = () => {
-	const idx = options?.indexOf(search.value ?? '') ?? -1
+	const idx = choiceList.value.indexOf(search.value ?? '')
 	dropdown.activeItemIndex = isAsync ? null : idx >= 0 ? idx : null
 	dropdown.open = true
-	// TODO: this should probably call the async function if it's async
-	dropdown.results = isAsync ? [] : options
+	dropdown.results = isAsync ? [] : choiceList.value
 }
 
 const closeDropdown = (result?: string) => {
 	dropdown.activeItemIndex = null
 	dropdown.open = false
-	if (!options?.includes(result || search.value || '')) {
+	if (!choiceList.value.includes(result || search.value || '')) {
 		search.value = committedValue.value
 	}
 }
 
 const filterResults = () => {
 	if (!search.value) {
-		dropdown.results = options
+		dropdown.results = choiceList.value
 	} else {
-		dropdown.results = options?.filter(item => item.toLowerCase().includes((search.value ?? '').toLowerCase()))
+		dropdown.results = choiceList.value.filter(item => item.toLowerCase().includes((search.value ?? '').toLowerCase()))
 	}
 }
 
@@ -157,65 +183,26 @@ const setCurrentResult = () => {
 </script>
 
 <style scoped>
-/* variables taken from here: https://github.com/frappe/frappe/blob/version-13/frappe/public/scss/common/awesomeplete.scss */
 .autocomplete {
 	position: relative;
 }
 
-.input-wrapper {
-	border: 1px solid transparent;
-	padding: 0rem;
-	margin: 0rem;
-	margin-right: 1ch;
-}
-
-input {
-	width: calc(100% - 1ch);
-	outline: 1px solid transparent;
-	border: 1px solid var(--sc-input-border-color);
-	padding: 1ch 0.5ch 0.5ch 1ch;
-	margin: calc(1.15rem / 2) 0 0 0;
-	min-height: 1.15rem;
-	border-radius: 0.25rem;
-	font-family: var(--sc-font-family);
-}
-
-input:focus {
-	border: 1px solid var(--sc-input-active-border-color);
-	border-radius: 0.25rem 0.25rem 0 0;
-	border-bottom: none;
-}
-
-label {
-	display: block;
-	min-height: 1.15rem;
-	padding: 0rem;
-	margin: 0rem;
-	border: 1px solid transparent;
-	margin-bottom: 0.25rem;
-	z-index: 0;
-	font-size: 80%;
-	position: absolute;
-	background: white;
-	margin: calc(-1.5rem - calc(2.15rem / 2)) 0 0 1ch;
-	padding: 0 0.25ch 0 0.25ch;
-}
-
 .autocomplete-results {
 	position: absolute;
-	width: calc(100% - 1ch + 1.5px);
+	left: 0;
+	right: 0;
 	z-index: 100;
 	padding: 0;
 	margin: 0;
 	color: var(--sc-input-active-border-color);
 	border: 1px solid var(--sc-input-active-border-color);
-	border-radius: 0 0 0.25rem 0.25rem;
+	border-radius: 0;
 	border-top: none;
-	background-color: #fff;
+	background-color: var(--sc-input-field-background, #fff);
+	list-style: none;
 }
 
 .autocomplete-result {
-	list-style: none;
 	text-align: left;
 	padding: 4px 6px;
 	cursor: pointer;
@@ -226,15 +213,5 @@ label {
 .autocomplete-result:hover {
 	background-color: var(--sc-row-color-zebra-light);
 	color: var(--sc-input-active-border-color);
-}
-
-/* Keep the field error in-flow below the control. The shared .aform_error is absolutely
-   positioned against a .aform_form-element anchor, which this component does not use. */
-p.aform_error {
-	position: static;
-	display: block;
-	color: var(--sc-brand-danger, red);
-	font-size: 0.7rem;
-	margin: 0.25rem 0 0;
 }
 </style>

--- a/aform/src/components/form/ADropdown.vue
+++ b/aform/src/components/form/ADropdown.vue
@@ -49,13 +49,14 @@ import { vOnClickOutside } from '@vueuse/components'
 import { computed, reactive, ref, watch } from 'vue'
 
 import type { ComponentProps } from '../../types'
+import type { BadgeFormatFn } from '../../utils/badge'
 import { badgeInputAccentStyle, resolveFieldBadge } from '../../utils/badge'
+import { deserializeFunction } from '../../utils/deserialize'
 
 const {
 	label,
 	options = [],
 	format,
-	record,
 	isAsync = false,
 	filterFunction = undefined,
 	mode,
@@ -65,7 +66,6 @@ const {
 	ComponentProps & {
 		options?: FieldOptions
 		format?: string
-		record?: Record<string, unknown>
 		isAsync?: boolean
 		filterFunction?: (search: string) => string[] | Promise<string[]>
 	}
@@ -73,7 +73,12 @@ const {
 
 const choiceList = computed(() => selectChoices(options))
 
-const badgeDescriptor = computed(() => resolveFieldBadge(search.value, options, format, { record, row: record }))
+// Compile the serialized formatter once per `format` string, not once per keystroke:
+// badgeDescriptor re-evaluates on every input event and deserializeFunction runs the
+// Function constructor.
+const formatFn = computed(() => (format ? deserializeFunction<BadgeFormatFn>(format) : undefined))
+
+const badgeDescriptor = computed(() => resolveFieldBadge(search.value, options, formatFn.value))
 
 const inputAccentStyle = computed(() => badgeInputAccentStyle(badgeDescriptor.value))
 

--- a/aform/src/index.ts
+++ b/aform/src/index.ts
@@ -1,5 +1,7 @@
 export type * from '@stonecrop/atable/types'
 export { deserializeFunction } from './utils/deserialize'
+export { badgeInputAccentStyle, resolveFieldBadge } from './utils/badge'
+export type { BadgeFormatContext, BadgeFormatFn } from './utils/badge'
 import { install as installATable } from '@stonecrop/atable'
 import type { App } from 'vue'
 
@@ -7,6 +9,7 @@ import ACheckbox from './components/form/ACheckbox.vue'
 import ACurrencyInput from './components/form/ACurrencyInput.vue'
 import ADate from './components/form/ADate.vue'
 import ADropdown from './components/form/ADropdown.vue'
+import ABadge from './components/form/ABadge.vue'
 import ADatePicker from './components/form/ADatePicker.vue'
 import ADateTime from './components/form/ADateTime.vue'
 import ADateTimeInput from './components/form/ADateTimeInput.vue'
@@ -38,6 +41,7 @@ function install(app: App /* options */) {
 	app.component('ACurrencyInput', ACurrencyInput)
 	app.component('ADate', ADate)
 	app.component('ADropdown', ADropdown)
+	app.component('ABadge', ABadge)
 	app.component('ADatePicker', ADatePicker)
 	app.component('ADateTime', ADateTime)
 	app.component('ADateTimeInput', ADateTimeInput)
@@ -60,6 +64,7 @@ export {
 	ACurrencyInput,
 	ADate,
 	ADropdown,
+	ABadge,
 	ADatePicker,
 	ADateRange,
 	ADateSelection,

--- a/aform/src/utils/badge.ts
+++ b/aform/src/utils/badge.ts
@@ -1,0 +1,77 @@
+import type { BadgeDescriptor, BadgeVariant, FieldOptions } from '@stonecrop/schema'
+import { isBadgeDescriptor, lookupBadge } from '@stonecrop/schema'
+
+import { deserializeFunction } from './deserialize'
+
+/**
+ * Row context passed to badge `format` functions in form fields.
+ * @public
+ */
+export type BadgeFormatContext = {
+	record?: Record<string, unknown>
+	row?: Record<string, unknown>
+}
+
+/**
+ * Badge-aware field `format` function signature.
+ * @public
+ */
+export type BadgeFormatFn = (value: unknown, context: BadgeFormatContext) => string | BadgeDescriptor
+
+/**
+ * Resolve a field value to a badge descriptor using format (if present) then options map.
+ * @public
+ */
+export function resolveFieldBadge(
+	value: unknown,
+	options: FieldOptions | undefined,
+	format: string | BadgeFormatFn | undefined,
+	context: BadgeFormatContext = {}
+): BadgeDescriptor | undefined {
+	if (format) {
+		let formatted: unknown
+		if (typeof format === 'function') {
+			formatted = format(value, context)
+		} else {
+			const formatFn = deserializeFunction<BadgeFormatFn>(format)
+			formatted = formatFn(value, context)
+		}
+		if (isBadgeDescriptor(formatted)) {
+			const label = formatted.label.trim()
+			return label ? formatted : undefined
+		}
+		if (typeof formatted === 'string' && formatted !== '') {
+			return lookupBadge(options, formatted) ?? { label: formatted, variant: 'neutral' }
+		}
+	}
+
+	if (value === null || value === undefined || value === '') return undefined
+	const key = typeof value === 'string' ? value : String(value)
+	return lookupBadge(options, key)
+}
+
+const BADGE_VARIANTS: BadgeVariant[] = ['neutral', 'success', 'warning', 'danger', 'brand']
+
+/**
+ * CSS custom properties for input-accent styling on a native input.
+ * @public
+ */
+export function badgeInputAccentStyle(descriptor: BadgeDescriptor | undefined): Record<string, string> | undefined {
+	if (!descriptor?.label?.trim()) return undefined
+	const variant = descriptor.variant ?? 'neutral'
+	if (descriptor.color) {
+		return {
+			borderLeftWidth: '4px',
+			borderLeftStyle: 'solid',
+			borderLeftColor: descriptor.color,
+			paddingLeft: 'calc(1ch - 4px)',
+		}
+	}
+	if (!BADGE_VARIANTS.includes(variant)) return undefined
+	return {
+		borderLeftWidth: '4px',
+		borderLeftStyle: 'solid',
+		borderLeftColor: `var(--sc-badge-${variant}-accent)`,
+		paddingLeft: 'calc(1ch - 4px)',
+	}
+}

--- a/aform/src/utils/badge.ts
+++ b/aform/src/utils/badge.ts
@@ -1,4 +1,4 @@
-import type { BadgeDescriptor, BadgeVariant, FieldOptions } from '@stonecrop/schema'
+import type { BadgeDescriptor, FieldOptions } from '@stonecrop/schema'
 import { isBadgeDescriptor, lookupBadge } from '@stonecrop/schema'
 
 import { deserializeFunction } from './deserialize'
@@ -45,12 +45,29 @@ export function resolveFieldBadge(
 		}
 	}
 
-	if (value === null || value === undefined || value === '') return undefined
-	const key = typeof value === 'string' ? value : String(value)
+	const key = badgeLookupKey(value)
+	if (key === undefined) return undefined
 	return lookupBadge(options, key)
 }
 
-const BADGE_VARIANTS: BadgeVariant[] = ['neutral', 'success', 'warning', 'danger', 'brand']
+/**
+ * Stored choice value as an options-map key. Only primitives can match a declared choice, so
+ * anything else yields undefined rather than the '[object Object]' that String() would produce.
+ */
+function badgeLookupKey(value: unknown): string | undefined {
+	switch (typeof value) {
+		case 'string':
+			return value === '' ? undefined : value
+		case 'number':
+		case 'boolean':
+		case 'bigint':
+			return String(value)
+		default:
+			return undefined
+	}
+}
+
+const BADGE_VARIANTS = new Set<string>(['neutral', 'success', 'warning', 'danger', 'brand'])
 
 /**
  * CSS custom properties for input-accent styling on a native input.
@@ -67,7 +84,7 @@ export function badgeInputAccentStyle(descriptor: BadgeDescriptor | undefined): 
 			paddingLeft: 'calc(1ch - 4px)',
 		}
 	}
-	if (!BADGE_VARIANTS.includes(variant)) return undefined
+	if (!BADGE_VARIANTS.has(variant)) return undefined
 	return {
 		borderLeftWidth: '4px',
 		borderLeftStyle: 'solid',

--- a/aform/tests/badge-cell-declared.spec.ts
+++ b/aform/tests/badge-cell-declared.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ACell, createTableStore } from '@stonecrop/atable'
+import type { TableColumn } from '@stonecrop/atable'
+
+import ABadge from '../src/components/form/ABadge.vue'
+
+// ACell resolves 'ABadge' by name, so the component has to be registered the way aform's
+// install() registers it. This lives in aform because atable cannot import it.
+const mountCell = (column: Partial<TableColumn>, row: Record<string, unknown>) =>
+	mount(ACell, {
+		props: {
+			colIndex: 0,
+			rowIndex: 0,
+			store: createTableStore({ columns: [column as TableColumn], rows: [row] }),
+		},
+		global: { components: { ABadge } },
+	})
+
+const badges = { choices: ['Open', 'Closed'], badges: { Open: 'warning', Closed: 'success' } }
+
+describe('cellComponent: ABadge', { tags: ['component'] }, () => {
+	beforeEach(() => setActivePinia(createPinia()))
+
+	it('CONTROL — the options branch paints a badge', () => {
+		const td = mountCell({ name: 'status', label: 'Status', options: badges }, { status: 'Open' })
+		expect(td.text()).toBe('Open')
+		expect(td.find('.abadge').classes()).toContain('abadge--warning')
+	})
+
+	it('the declared cellComponent route paints the same badge', () => {
+		const td = mountCell(
+			{ name: 'status', label: 'Status', cellComponent: 'ABadge', options: badges },
+			{ status: 'Open' }
+		)
+		expect(td.text()).toBe('Open')
+		expect(td.find('.abadge').classes()).toContain('abadge--warning')
+	})
+
+	it('hands ABadge the options it needs', () => {
+		const td = mountCell(
+			{ name: 'status', label: 'Status', cellComponent: 'ABadge', options: badges },
+			{ status: 'Open' }
+		)
+		const badge = td.findComponent(ABadge)
+		expect(badge.props('options')).toEqual(badges)
+		expect(badge.props('presentation')).toBe('cell-fill')
+	})
+
+	it('hands ABadge the stored value, not the formatted text', () => {
+		const td = mountCell(
+			{ name: 'status', label: 'Status', cellComponent: 'ABadge', options: badges, format: '(v) => v.toUpperCase()' },
+			{ status: 'Open' }
+		)
+		expect(td.findComponent(ABadge).props('value')).toBe('Open')
+	})
+})

--- a/aform/tests/badge.spec.ts
+++ b/aform/tests/badge.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ABadge from '../src/components/form/ABadge.vue'
+import { badgeInputAccentStyle, resolveFieldBadge } from '../src/utils/badge'
+
+describe('ABadge', { tags: ['component'] }, () => {
+	it('renders nothing when label is empty', () => {
+		const wrapper = mount(ABadge, {
+			props: { label: '', presentation: 'cell-fill' },
+		})
+		expect(wrapper.find('.abadge').exists()).toBe(false)
+	})
+
+	it('renders cell-fill with variant class', () => {
+		const wrapper = mount(ABadge, {
+			props: { label: 'Open', variant: 'warning', presentation: 'cell-fill' },
+		})
+		expect(wrapper.text()).toBe('Open')
+		expect(wrapper.classes()).toContain('abadge--cell-fill')
+		expect(wrapper.classes()).toContain('abadge--warning')
+	})
+
+	it('renders input-accent presentation', () => {
+		const wrapper = mount(ABadge, {
+			props: { label: 'Submitted', variant: 'success', presentation: 'input-accent' },
+		})
+		expect(wrapper.classes()).toContain('abadge--input-accent')
+		expect(wrapper.classes()).toContain('abadge--success')
+	})
+
+	it('resolves value and options when label is omitted', () => {
+		const wrapper = mount(ABadge, {
+			props: {
+				value: 'Open',
+				options: { Open: 'danger', Closed: 'success' },
+				presentation: 'cell-fill',
+			},
+		})
+		expect(wrapper.text()).toBe('Open')
+		expect(wrapper.classes()).toContain('abadge--danger')
+	})
+})
+
+describe('resolveFieldBadge', { tags: ['component'] }, () => {
+	it('returns descriptor from format function', () => {
+		const result = resolveFieldBadge(
+			'Draft',
+			['Draft', 'Submitted'],
+			() => ({ label: 'To Bill', variant: 'warning' }),
+			{ row: { per_billed: 0 } }
+		)
+		expect(result).toEqual({ label: 'To Bill', variant: 'warning' })
+	})
+
+	it('falls back to options map when format returns a string key', () => {
+		const result = resolveFieldBadge('Open', { Open: 'warning' }, () => 'Open', {})
+		expect(result).toEqual({ label: 'Open', variant: 'warning' })
+	})
+
+	it('looks up stored value when format is absent', () => {
+		expect(resolveFieldBadge('Completed', { Completed: 'success' }, undefined, {})).toEqual({
+			label: 'Completed',
+			variant: 'success',
+		})
+	})
+})
+
+describe('badgeInputAccentStyle', { tags: ['component'] }, () => {
+	it('returns border styles for a variant', () => {
+		expect(badgeInputAccentStyle({ label: 'Open', variant: 'warning' })).toEqual({
+			borderLeftWidth: '4px',
+			borderLeftStyle: 'solid',
+			borderLeftColor: 'var(--sc-badge-warning-accent)',
+			paddingLeft: 'calc(1ch - 4px)',
+		})
+	})
+
+	it('returns undefined when label is empty', () => {
+		expect(badgeInputAccentStyle(undefined)).toBeUndefined()
+	})
+})

--- a/aform/tests/dropdown-badge.spec.ts
+++ b/aform/tests/dropdown-badge.spec.ts
@@ -1,0 +1,58 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ADropdown from '../src/components/form/ADropdown.vue'
+
+describe('ADropdown badge display', { tags: ['component'] }, () => {
+	const badgeOptions = {
+		choices: ['Open', 'Working', 'Completed'],
+		badges: {
+			Open: 'warning',
+			Working: 'brand',
+			Completed: 'success',
+		},
+	}
+
+	it('renders badge label with input accent in display mode', () => {
+		const wrapper = mount(ADropdown, {
+			props: {
+				modelValue: 'Open',
+				label: 'Status',
+				options: badgeOptions,
+				mode: 'display',
+			},
+		})
+		const display = wrapper.find('.aform_display-value')
+		expect(display.text()).toBe('Open')
+		expect(display.attributes('style')).toContain('border-left-color')
+		expect(display.attributes('style')).toContain('var(--sc-badge-warning-accent)')
+	})
+
+	it('applies input accent style in edit mode', () => {
+		const wrapper = mount(ADropdown, {
+			props: {
+				modelValue: 'Completed',
+				label: 'Status',
+				options: badgeOptions,
+				mode: 'edit',
+			},
+		})
+		const input = wrapper.find('input')
+		expect(input.attributes('style')).toContain('border-left-color')
+		expect(input.attributes('style')).toContain('var(--sc-badge-success-accent)')
+	})
+
+	it('still uses choices for edit dropdown filtering', async () => {
+		const wrapper = mount(ADropdown, {
+			props: {
+				modelValue: 'Open',
+				label: 'Status',
+				options: badgeOptions,
+				mode: 'edit',
+			},
+		})
+		await wrapper.find('input').trigger('focus')
+		const items = wrapper.findAll('.autocomplete-result')
+		expect(items.map(li => li.text())).toEqual(['Open', 'Working', 'Completed'])
+	})
+})

--- a/atable/api.md
+++ b/atable/api.md
@@ -151,7 +151,7 @@ createTableStore: (initData: {
 }) => import("pinia").Store<`table-${string}`, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -178,7 +178,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1025,7 +1025,7 @@ createTableStore: (initData: {
 }, "columns" | "config" | "connectionHandles" | "connectionPaths" | "filterState" | "ganttBars" | "modal" | "rows" | "sortState" | "updates" | "linkResolver">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1052,7 +1052,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1899,7 +1899,7 @@ createTableStore: (initData: {
 }, "display" | "table" | "filteredRows" | "hasPinnedColumns" | "isGanttView" | "isTreeView" | "isDependencyGraphEnabled" | "numberedRowWidth" | "zeroColumn">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1926,7 +1926,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;

--- a/atable/api.md
+++ b/atable/api.md
@@ -151,7 +151,7 @@ createTableStore: (initData: {
 }) => import("pinia").Store<`table-${string}`, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -172,12 +172,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -198,6 +199,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -1023,7 +1025,7 @@ createTableStore: (initData: {
 }, "columns" | "config" | "connectionHandles" | "connectionPaths" | "filterState" | "ganttBars" | "modal" | "rows" | "sortState" | "updates" | "linkResolver">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1044,12 +1046,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1070,6 +1073,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -1895,7 +1899,7 @@ createTableStore: (initData: {
 }, "display" | "table" | "filteredRows" | "hasPinnedColumns" | "isGanttView" | "isTreeView" | "isDependencyGraphEnabled" | "numberedRowWidth" | "zeroColumn">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1916,12 +1920,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1942,6 +1947,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -3250,7 +3256,7 @@ Schema-based callers should author columns as `ColumnSchema[]` (using `fieldname
 
 ```typescript
 export interface TableColumn {
-  format?: string | ((value: any, context: CellContext) => string);
+  format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor);
   linkDoctype?: string;
   mask?: (value: any) => any;
   modalComponent?: string | ((context: CellContext) => string);
@@ -3263,7 +3269,7 @@ export interface TableColumn {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| format? | `string \| ((value: any, context: CellContext) => string)` | Widens `ColumnSchema.format` (string-only) to also accept a live function at runtime. Serialized string functions are deserialized by the table store's `getFormattedValue`. |
+| format? | `string \| ((value: any, context: CellContext) => string \| BadgeDescriptor)` | Widens `ColumnSchema.format` (string-only) to also accept a live function at runtime. Serialized string functions are deserialized by the table store's `getFormattedValue`. May return a plain string, HTML, or a `BadgeDescriptor`. |
 | linkDoctype? | `string` | For link columns (those carrying `doctype`): the target doctype slug used by the `linkResolver` to look up display text for bare ID values. Set automatically by `schemaToColumns` from the field's `doctype` property. |
 | mask? | `(value: any) => any` | Input mask applied to the cell value before display. Accepts a live function only — masks cannot be serialized to JSON so they are absent from `ColumnSchema`. |
 | modalComponent? | `string \| ((context: CellContext) => string)` | Widens `ColumnSchema.modalComponent` (string-only) to also accept a factory function. When a function is provided it receives the cell context and returns the component name. The cell context exposes: - `row` — the row object for the current cell - `column` — the column object for the current cell - `table` — the table object |

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -116,7 +116,7 @@ const usesBadgeDisplay = computed(
 const isContentEditable = computed(() => column.edit && !usesBadgeDisplay.value)
 
 const cellComponentBindings = computed(() => {
-	const props = { ...(column.cellComponentProps ?? {}) }
+	const props = { ...column.cellComponentProps }
 	if (column.cellComponent === 'ABadge') {
 		if (isBadgeDescriptor(renderedValue.value)) {
 			return { ...props, ...renderedValue.value }

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -117,13 +117,20 @@ const isContentEditable = computed(() => column.edit && !usesBadgeDisplay.value)
 
 const cellComponentBindings = computed(() => {
 	const props = { ...column.cellComponentProps }
-	if (column.cellComponent === 'ABadge') {
-		if (isBadgeDescriptor(renderedValue.value)) {
-			return { ...props, ...renderedValue.value }
-		}
+	if (column.cellComponent !== 'ABadge') {
 		return { ...props, value: renderedValue.value }
 	}
-	return { ...props, value: renderedValue.value }
+	if (isBadgeDescriptor(renderedValue.value)) {
+		return { presentation: 'cell-fill' as const, ...props, ...renderedValue.value }
+	}
+	// ABadge resolves its own label, so it needs the badge map as well as the value — and the value
+	// has to be the stored one, because badge maps are keyed on that rather than on formatted text.
+	return {
+		presentation: 'cell-fill' as const,
+		options: column.options,
+		...props,
+		value: store.getCellData(colIndex, rowIndex),
+	}
 })
 
 const isHtmlValue = computed(() => {

--- a/atable/src/components/ACell.vue
+++ b/atable/src/components/ACell.vue
@@ -4,7 +4,7 @@
 		:data-colindex="colIndex"
 		:data-rowindex="rowIndex"
 		:data-editable="column.edit"
-		:contenteditable="column.edit"
+		:contenteditable="isContentEditable"
 		:tabindex="tabIndex"
 		:spellcheck="false"
 		:style="cellStyle"
@@ -14,11 +14,9 @@
 		@paste="updateCellData"
 		@input="debouncedUpdateCellData"
 		@click="onCellClick">
-		<component
-			:is="column.cellComponent"
-			v-if="column.cellComponent"
-			:value="renderedValue"
-			v-bind="column.cellComponentProps" />
+		<component :is="column.cellComponent" v-if="column.cellComponent" v-bind="cellComponentBindings" />
+		<component :is="'ABadge'" v-else-if="badgeFromFormat" v-bind="badgeFromFormat" presentation="cell-fill" />
+		<component :is="'ABadge'" v-else-if="badgeFromOptions" v-bind="badgeFromOptions" />
 		<span v-else-if="isHtmlValue" v-html="renderedValue" />
 		<span v-else>{{ renderedValue }}</span>
 	</td>
@@ -26,6 +24,7 @@
 
 <script setup lang="ts">
 import { KeypressHandlers, defaultKeypressHandlers, useKeyboardNav } from '@stonecrop/utilities'
+import { isBadgeDescriptor, hasBadgeOptions } from '@stonecrop/schema'
 import { useDebounceFn, useElementBounding } from '@vueuse/core'
 import { computed, type CSSProperties, onMounted, ref, useTemplateRef, nextTick } from 'vue'
 
@@ -94,6 +93,39 @@ onMounted(() => {
 
 const renderedValue = computed(() => resolvedText.value ?? displayValue.value)
 
+const badgeFromFormat = computed(() => {
+	if (column.cellComponent) return undefined
+	const value = renderedValue.value
+	return isBadgeDescriptor(value) ? value : undefined
+})
+
+const badgeFromOptions = computed(() => {
+	if (column.cellComponent || badgeFromFormat.value) return undefined
+	if (!hasBadgeOptions(column.options)) return undefined
+	return {
+		value: store.getCellData(colIndex, rowIndex),
+		options: column.options,
+		presentation: 'cell-fill' as const,
+	}
+})
+
+const usesBadgeDisplay = computed(
+	() => !!column.cellComponent || badgeFromFormat.value !== undefined || hasBadgeOptions(column.options)
+)
+
+const isContentEditable = computed(() => column.edit && !usesBadgeDisplay.value)
+
+const cellComponentBindings = computed(() => {
+	const props = { ...(column.cellComponentProps ?? {}) }
+	if (column.cellComponent === 'ABadge') {
+		if (isBadgeDescriptor(renderedValue.value)) {
+			return { ...props, ...renderedValue.value }
+		}
+		return { ...props, value: renderedValue.value }
+	}
+	return { ...props, value: renderedValue.value }
+})
+
 const isHtmlValue = computed(() => {
 	// TODO: check if display value is a native DOM element
 	return typeof renderedValue.value === 'string' ? isHtmlString(renderedValue.value) : false
@@ -112,6 +144,7 @@ const cellClasses = computed(() => {
 	return {
 		'sticky-column': pinned,
 		'cell-modified': cellModified.value,
+		'atable-cell--badge-fill': usesBadgeDisplay.value,
 	}
 })
 
@@ -362,5 +395,9 @@ defineExpose({
 }
 .cell-modified-highlight {
 	background-color: var(--sc-cell-changed-color);
+}
+.atable-cell--badge-fill {
+	padding: 0 !important;
+	margin-left: 0;
 }
 </style>

--- a/atable/src/stores/table.ts
+++ b/atable/src/stores/table.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { componentCategory } from '@stonecrop/schema'
+import type { BadgeDescriptor } from '@stonecrop/schema'
 import { type CSSProperties, computed, ref } from 'vue'
 
 import type {
@@ -549,10 +550,11 @@ export const createTableStore = (initData: {
 			if (typeof format === 'function') {
 				return format(value, { table: table.value, row, column })
 			} else if (typeof format === 'string') {
-				// parse format function from string
+				// parse format function from string. The alias keeps the declaration on one line so the
+				// disable directive below stays attached to the Function call it covers.
+				type DeserializedFormat = (value: any, context?: CellContext) => string | BadgeDescriptor
 				// oxlint-disable-next-line @typescript-eslint/no-implied-eval
-				const formatFn: (value: any, context?: CellContext) => string | import('@stonecrop/schema').BadgeDescriptor =
-					Function(`"use strict";return (${format})`)()
+				const formatFn: DeserializedFormat = Function(`"use strict";return (${format})`)()
 				return formatFn(value, { table: table.value, row, column })
 			}
 

--- a/atable/src/stores/table.ts
+++ b/atable/src/stores/table.ts
@@ -551,7 +551,8 @@ export const createTableStore = (initData: {
 			} else if (typeof format === 'string') {
 				// parse format function from string
 				// oxlint-disable-next-line @typescript-eslint/no-implied-eval
-				const formatFn: (value: any, context?: CellContext) => string = Function(`"use strict";return (${format})`)()
+				const formatFn: (value: any, context?: CellContext) => string | import('@stonecrop/schema').BadgeDescriptor =
+					Function(`"use strict";return (${format})`)()
 				return formatFn(value, { table: table.value, row, column })
 			}
 

--- a/atable/src/types/index.ts
+++ b/atable/src/types/index.ts
@@ -2,6 +2,7 @@ import { useElementBounding } from '@vueuse/core'
 import type { Ref, ShallowRef } from 'vue'
 
 import type { ColumnSchema } from '@stonecrop/schema'
+import type { BadgeDescriptor } from '@stonecrop/schema'
 
 import { createTableStore } from '../stores/table'
 
@@ -25,8 +26,9 @@ export interface TableColumn extends Omit<ColumnSchema, 'fieldname' | 'hidden' |
 	/**
 	 * Widens `ColumnSchema.format` (string-only) to also accept a live function at runtime.
 	 * Serialized string functions are deserialized by the table store's `getFormattedValue`.
+	 * May return a plain string, HTML, or a {@link @stonecrop/schema#BadgeDescriptor}.
 	 */
-	format?: string | ((value: any, context: CellContext) => string)
+	format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor)
 
 	/**
 	 * Widens `ColumnSchema.modalComponent` (string-only) to also accept a factory function.

--- a/atable/tests/badge-cell.spec.ts
+++ b/atable/tests/badge-cell.spec.ts
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+
+import ACell from '../src/components/ACell.vue'
+import { createTableStore } from '../src/stores/table'
+import type { TableColumn } from '../src/types'
+
+// ACell renders ABadge by global registration (it lives in @stonecrop/aform, which atable
+// cannot import). A stub stands in so these tests pin what ACell *passes*, independent of
+// how aform paints it.
+const ABadgeStub = defineComponent({
+	props: {
+		presentation: { type: String, required: true },
+		label: { type: String, default: undefined },
+		variant: { type: String, default: undefined },
+		value: { type: null, default: undefined },
+		options: { type: null, default: undefined },
+	},
+	template: `<span class="badge-stub" :data-presentation="presentation" :data-variant="variant"
+		:data-label="label" :data-value="value">{{ label ?? value }}</span>`,
+})
+
+const mountCell = (columns: TableColumn[], rows: Record<string, unknown>[]) =>
+	mount(ACell, {
+		props: { colIndex: 0, rowIndex: 0, store: createTableStore({ columns, rows }) },
+		global: { components: { ABadge: ABadgeStub } },
+	})
+
+describe('ACell badge rendering', { tags: ['component'] }, () => {
+	beforeEach(() => setActivePinia(createPinia()))
+
+	const badgeOptions = { choices: ['Open', 'Closed'], badges: { Open: 'warning', Closed: 'success' } }
+
+	it('renders a cell-fill badge from a badge map on options', () => {
+		const wrapper = mountCell([{ name: 'status', component: 'ADropdown', options: badgeOptions }], [{ status: 'Open' }])
+		const badge = wrapper.find('.badge-stub')
+		expect(badge.exists()).toBe(true)
+		expect(badge.attributes('data-presentation')).toBe('cell-fill')
+		expect(badge.attributes('data-value')).toBe('Open')
+	})
+
+	it('passes the raw stored value, not the formatted text, for options lookup', () => {
+		const wrapper = mountCell(
+			[{ name: 'status', component: 'ADropdown', options: badgeOptions, format: (v: any) => `<${String(v)}>` }],
+			[{ status: 'Closed' }]
+		)
+		// format returns a plain string here, so the options branch still owns the lookup and
+		// must key off the stored value.
+		expect(wrapper.find('.badge-stub').attributes('data-value')).toBe('Closed')
+	})
+
+	it('renders a descriptor returned by format in preference to the options map', () => {
+		const wrapper = mountCell(
+			[
+				{
+					name: 'status',
+					component: 'ADropdown',
+					options: badgeOptions,
+					format: () => ({ label: 'Overdue', variant: 'danger' as const }),
+				},
+			],
+			[{ status: 'Open' }]
+		)
+		const badge = wrapper.find('.badge-stub')
+		expect(badge.attributes('data-label')).toBe('Overdue')
+		expect(badge.attributes('data-variant')).toBe('danger')
+		expect(badge.attributes('data-presentation')).toBe('cell-fill')
+	})
+
+	it('leaves a plain string[] select as text, with no badge', () => {
+		const wrapper = mountCell(
+			[{ name: 'status', component: 'ADropdown', options: ['Open', 'Closed'] }],
+			[{ status: 'Open' }]
+		)
+		expect(wrapper.find('.badge-stub').exists()).toBe(false)
+		expect(wrapper.text()).toBe('Open')
+	})
+
+	it('leaves a column with no options as text, with no badge', () => {
+		const wrapper = mountCell([{ name: 'note', component: 'ATextInput' }], [{ note: 'hello' }])
+		expect(wrapper.find('.badge-stub').exists()).toBe(false)
+		expect(wrapper.text()).toBe('hello')
+	})
+})

--- a/atable/tests/badge-format.spec.ts
+++ b/atable/tests/badge-format.spec.ts
@@ -1,0 +1,30 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { createTableStore } from '../src/stores/table'
+import type { TableColumn } from '../src/types'
+
+describe('getFormattedValue badge descriptors', { tags: ['component'] }, () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	it('returns a BadgeDescriptor when format returns one', () => {
+		const columns: TableColumn[] = [
+			{
+				name: 'status',
+				component: 'ADropdown',
+				format: () => ({
+					label: 'Overdue',
+					variant: 'danger' as const,
+				}),
+			},
+		]
+		const store = createTableStore({
+			columns,
+			rows: [{ status: 'Open' }],
+		})
+		const result = store.getFormattedValue(0, 0, 'Open')
+		expect(result).toEqual({ label: 'Overdue', variant: 'danger' })
+	})
+})

--- a/atable/tests/schema-to-columns.spec.ts
+++ b/atable/tests/schema-to-columns.spec.ts
@@ -163,6 +163,66 @@ describe('schemaToColumns', { tags: ['component'] }, () => {
 		})
 	})
 
+	describe('Select badge handling', () => {
+		it('preserves badge options on select fields for ACell rendering', () => {
+			const schema: ColumnSchema[] = [
+				{
+					fieldname: 'status',
+					component: 'ADropdown',
+					label: 'Status',
+					options: {
+						choices: ['Open', 'Closed'],
+						badges: { Open: 'warning', Closed: 'success' },
+					},
+				},
+			]
+			const columns = schemaToColumns(schema)
+			expect(columns[0].options).toEqual(schema[0].options)
+			expect(columns[0].cellComponent).toBeUndefined()
+		})
+
+		it('preserves bare choice maps on select fields', () => {
+			const schema: ColumnSchema[] = [
+				{
+					fieldname: 'status',
+					component: 'ADropdown',
+					label: 'Status',
+					options: { Open: 'warning', Closed: 'neutral' },
+				},
+			]
+			const columns = schemaToColumns(schema)
+			expect(columns[0].options).toEqual(schema[0].options)
+			expect(columns[0].cellComponent).toBeUndefined()
+		})
+
+		it('does not attach ABadge when cellComponent is explicit', () => {
+			const schema: ColumnSchema[] = [
+				{
+					fieldname: 'status',
+					component: 'ADropdown',
+					label: 'Status',
+					options: { Open: 'warning' },
+					cellComponent: 'StatusBadge',
+				},
+			]
+			const columns = schemaToColumns(schema)
+			expect(columns[0].cellComponent).toBe('StatusBadge')
+		})
+
+		it('does not attach ABadge for plain string[] selects', () => {
+			const schema: ColumnSchema[] = [
+				{
+					fieldname: 'status',
+					component: 'ADropdown',
+					label: 'Status',
+					options: ['Open', 'Closed'],
+				},
+			]
+			const columns = schemaToColumns(schema)
+			expect(columns[0].cellComponent).toBeUndefined()
+		})
+	})
+
 	describe('Currency field handling', () => {
 		it('adds a formatCurrency function for currency-category fields without explicit format', () => {
 			const schema: ColumnSchema[] = [{ fieldname: 'total', component: 'ACurrencyInput', label: 'Total' }]

--- a/atable/tests/schema-to-columns.spec.ts
+++ b/atable/tests/schema-to-columns.spec.ts
@@ -164,7 +164,10 @@ describe('schemaToColumns', { tags: ['component'] }, () => {
 	})
 
 	describe('Select badge handling', () => {
-		it('preserves badge options on select fields for ACell rendering', () => {
+		// schemaToColumns does not interpret badge options — it only has to carry `options`
+		// through untouched, because ACell is what reads them. Anything asserting that
+		// schemaToColumns sets `cellComponent` would pass whether or not that code existed.
+		it('carries structured badge options through to the column', () => {
 			const schema: ColumnSchema[] = [
 				{
 					fieldname: 'status',
@@ -178,10 +181,9 @@ describe('schemaToColumns', { tags: ['component'] }, () => {
 			]
 			const columns = schemaToColumns(schema)
 			expect(columns[0].options).toEqual(schema[0].options)
-			expect(columns[0].cellComponent).toBeUndefined()
 		})
 
-		it('preserves bare choice maps on select fields', () => {
+		it('carries bare choice maps through to the column', () => {
 			const schema: ColumnSchema[] = [
 				{
 					fieldname: 'status',
@@ -192,24 +194,9 @@ describe('schemaToColumns', { tags: ['component'] }, () => {
 			]
 			const columns = schemaToColumns(schema)
 			expect(columns[0].options).toEqual(schema[0].options)
-			expect(columns[0].cellComponent).toBeUndefined()
 		})
 
-		it('does not attach ABadge when cellComponent is explicit', () => {
-			const schema: ColumnSchema[] = [
-				{
-					fieldname: 'status',
-					component: 'ADropdown',
-					label: 'Status',
-					options: { Open: 'warning' },
-					cellComponent: 'StatusBadge',
-				},
-			]
-			const columns = schemaToColumns(schema)
-			expect(columns[0].cellComponent).toBe('StatusBadge')
-		})
-
-		it('does not attach ABadge for plain string[] selects', () => {
+		it('carries plain string[] choices through to the column', () => {
 			const schema: ColumnSchema[] = [
 				{
 					fieldname: 'status',
@@ -219,7 +206,7 @@ describe('schemaToColumns', { tags: ['component'] }, () => {
 				},
 			]
 			const columns = schemaToColumns(schema)
-			expect(columns[0].cellComponent).toBeUndefined()
+			expect(columns[0].options).toEqual(['Open', 'Closed'])
 		})
 	})
 

--- a/common/changes/@stonecrop/aform/badge_component_2026-08-18-00-54-27.json
+++ b/common/changes/@stonecrop/aform/badge_component_2026-08-18-00-54-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Badge component with cell-fill and input-accent presentations for Select fields",
+      "type": "minor",
+      "packageName": "@stonecrop/aform"
+    }
+  ],
+  "packageName": "@stonecrop/aform",
+  "email": "tyler@agritheory.com"
+}

--- a/common/changes/@stonecrop/atable/badge_component_2026-08-18-00-54-27.json
+++ b/common/changes/@stonecrop/atable/badge_component_2026-08-18-00-54-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Badge component with cell-fill and input-accent presentations for Select fields",
+      "type": "none",
+      "packageName": "@stonecrop/atable"
+    }
+  ],
+  "packageName": "@stonecrop/atable",
+  "email": "tyler@agritheory.com"
+}

--- a/common/changes/@stonecrop/schema/badge_component_2026-08-18-00-54-27.json
+++ b/common/changes/@stonecrop/schema/badge_component_2026-08-18-00-54-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Badge component with cell-fill and input-accent presentations for Select fields",
+      "type": "none",
+      "packageName": "@stonecrop/schema"
+    }
+  ],
+  "packageName": "@stonecrop/schema",
+  "email": "tyler@agritheory.com"
+}

--- a/common/changes/@stonecrop/themes/badge_component_2026-08-18-00-54-27.json
+++ b/common/changes/@stonecrop/themes/badge_component_2026-08-18-00-54-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Badge component with cell-fill and input-accent presentations for Select fields",
+      "type": "none",
+      "packageName": "@stonecrop/themes"
+    }
+  ],
+  "packageName": "@stonecrop/themes",
+  "email": "tyler@agritheory.com"
+}

--- a/common/reviews/api/aform.api.md
+++ b/common/reviews/api/aform.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import ABadge from './components/form/ABadge.vue';
 import ACheckbox from './components/form/ACheckbox.vue';
 import ACurrencyInput from './components/form/ACurrencyInput.vue';
 import ADate from './components/form/ADate.vue';
@@ -24,12 +25,16 @@ import type { App } from 'vue';
 import AQuantityInput from './components/form/AQuantityInput.vue';
 import ATextboxInput from './components/form/ATextboxInput.vue';
 import ATextInput from './components/form/ATextInput.vue';
+import type { BadgeDescriptor } from '@stonecrop/schema';
 import type { ColumnSchema } from '@stonecrop/schema';
+import type { FieldOptions } from '@stonecrop/schema';
 import type { FieldValidation } from '@stonecrop/schema';
 import { InteractionMode } from '@stonecrop/schema';
 import Login from './components/utilities/Login.vue';
 import type { TableViewConfig } from '@stonecrop/schema';
 import type { ValueField } from '@stonecrop/schema';
+
+export { ABadge }
 
 export { ACheckbox }
 
@@ -83,6 +88,18 @@ export { AQuantityInput }
 export { ATextboxInput }
 
 export { ATextInput }
+
+// @public
+export type BadgeFormatContext = {
+    record?: Record<string, unknown>;
+    row?: Record<string, unknown>;
+};
+
+// @public
+export type BadgeFormatFn = (value: unknown, context: BadgeFormatContext) => string | BadgeDescriptor;
+
+// @public
+export function badgeInputAccentStyle(descriptor: BadgeDescriptor | undefined): Record<string, string> | undefined;
 
 // @public
 export type ComponentProps = {
@@ -194,6 +211,9 @@ export interface ResolvedTable {
     schema: ColumnSchema[];
     validation?: FieldValidation;
 }
+
+// @public
+export function resolveFieldBadge(value: unknown, options: FieldOptions | undefined, format: string | BadgeFormatFn | undefined, context?: BadgeFormatContext): BadgeDescriptor | undefined;
 
 
 export * from "@stonecrop/atable/types";

--- a/common/reviews/api/atable.api.md
+++ b/common/reviews/api/atable.api.md
@@ -15,11 +15,13 @@ import ATableHeader from './components/ATableHeader.vue';
 import ATableLoading from './components/ATableLoading.vue';
 import ATableLoadingBar from './components/ATableLoadingBar.vue';
 import ATableModal from './components/ATableModal.vue';
+import { BadgeDescriptor } from '@stonecrop/schema';
 import type { ColumnSchema } from '@stonecrop/schema';
 import { ComputedRef } from 'vue';
 import { CSSProperties } from 'vue';
 import DeleteIcon from './stonecrop-ui-icon-delete.svg?raw';
 import DuplicateIcon from './stonecrop-ui-icon-duplicate.svg?raw';
+import { FieldOptions } from '@stonecrop/schema';
 import InsertAboveIcon from './stonecrop-ui-icon-insert-above.svg?raw';
 import InsertBelowIcon from './stonecrop-ui-icon-insert-below.svg?raw';
 import MoveIcon from './stonecrop-ui-icon-move.svg?raw';
@@ -123,7 +125,7 @@ export const createTableStore: (initData: {
 }) => Store<`table-${string}`, Pick<{
 columns: Ref<    {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -144,12 +146,13 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
 }[], TableColumn[] | {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -170,6 +173,7 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
@@ -995,7 +999,7 @@ updateRows: (newRows: TableRow[]) => void;
 }, "columns" | "config" | "connectionHandles" | "connectionPaths" | "filterState" | "ganttBars" | "modal" | "rows" | "sortState" | "updates" | "linkResolver">, Pick<{
 columns: Ref<    {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -1016,12 +1020,13 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
 }[], TableColumn[] | {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -1042,6 +1047,7 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
@@ -1867,7 +1873,7 @@ updateRows: (newRows: TableRow[]) => void;
 }, "display" | "table" | "filteredRows" | "hasPinnedColumns" | "isGanttView" | "isTreeView" | "isDependencyGraphEnabled" | "numberedRowWidth" | "zeroColumn">, Pick<{
 columns: Ref<    {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -1888,12 +1894,13 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
 }[], TableColumn[] | {
 name: string;
-format?: string | ((value: any, context: CellContext) => string) | undefined;
+format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
 modalComponent?: string | ((context: CellContext) => string) | undefined;
 mask?: ((value: any) => any) | undefined;
 linkDoctype?: string | undefined;
@@ -1914,6 +1921,7 @@ filterComponent?: string | undefined;
 cellComponent?: string | undefined;
 cellComponentProps?: Record<string, any> | undefined;
 modalComponentExtraProps?: Record<string, any> | undefined;
+options?: FieldOptions | undefined;
 isGantt?: boolean | undefined;
 ganttComponent?: string | undefined;
 colspan?: number | undefined;
@@ -2897,7 +2905,7 @@ export function schemaToColumns(schema: ColumnSchema[]): TableColumn[];
 
 // @public
 export interface TableColumn extends Omit<ColumnSchema, 'fieldname' | 'hidden' | 'format' | 'modalComponent'> {
-    format?: string | ((value: any, context: CellContext) => string);
+    format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor);
     linkDoctype?: string;
     mask?: (value: any) => any;
     modalComponent?: string | ((context: CellContext) => string);

--- a/common/reviews/api/atable.api.md
+++ b/common/reviews/api/atable.api.md
@@ -15,7 +15,7 @@ import ATableHeader from './components/ATableHeader.vue';
 import ATableLoading from './components/ATableLoading.vue';
 import ATableLoadingBar from './components/ATableLoadingBar.vue';
 import ATableModal from './components/ATableModal.vue';
-import { BadgeDescriptor } from '@stonecrop/schema';
+import type { BadgeDescriptor } from '@stonecrop/schema';
 import type { ColumnSchema } from '@stonecrop/schema';
 import { ComputedRef } from 'vue';
 import { CSSProperties } from 'vue';

--- a/common/reviews/api/schema.api.md
+++ b/common/reviews/api/schema.api.md
@@ -26,6 +26,35 @@ export type ActionDefinition = z.infer<typeof ActionDefinition>;
 // @public
 export type AuthoredDoctype = Record<string, unknown>;
 
+// @public
+export interface BadgeDescriptor {
+    // (undocumented)
+    color?: string;
+    // (undocumented)
+    label: string;
+    // (undocumented)
+    variant?: BadgeVariant;
+}
+
+// @public
+export type BadgePresentation = 'cell-fill' | 'input-accent';
+
+// @public
+export type BadgeSpec = BadgeVariant | BadgeSpecObject;
+
+// @public
+export interface BadgeSpecObject {
+    // (undocumented)
+    color?: string;
+    // (undocumented)
+    label?: string;
+    // (undocumented)
+    variant?: BadgeVariant;
+}
+
+// @public
+export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'brand';
+
 // Warning: (ae-forgotten-export) The symbol "FieldTemplate" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -75,6 +104,7 @@ export interface ColumnSchema {
     label?: string;
     modalComponent?: string;
     modalComponentExtraProps?: Record<string, any>;
+    options?: FieldOptions;
     pinned?: boolean;
     resizable?: boolean;
     sortable?: boolean;
@@ -356,6 +386,9 @@ export interface GraphQLConversionOptions {
 }
 
 // @public
+export function hasBadgeOptions(options: FieldOptions | undefined): boolean;
+
+// @public
 export type InteractionMode = 'edit' | 'read' | 'display';
 
 // @public
@@ -371,6 +404,15 @@ export type IntrospectionSource = IntrospectionQuery | string;
 export function isActionAllowedInState(action: {
     allowedStates?: string[] | null;
 }, currentState: string): boolean;
+
+// @public
+export function isBadgeDescriptor(value: unknown): value is BadgeDescriptor;
+
+// @public
+export function isSelectChoiceMap(options: FieldOptions | undefined): options is Record<string, BadgeSpec>;
+
+// @public
+export function isSelectOptions(options: FieldOptions | undefined): options is SelectOptions;
 
 // @public
 export const LazyFetch: z.ZodObject<{
@@ -420,6 +462,9 @@ export type LinkExpansion = 'inline' | 'expand';
 export type LinkRenderMode = 'inline' | 'record' | 'table';
 
 // @public
+export function lookupBadge(options: FieldOptions | undefined, key: string | undefined): BadgeDescriptor | undefined;
+
+// @public
 export function mergeIntrospectedDoctype(authored: AuthoredDoctype, generated: ConvertedGraphQLDoctype): MergeResult;
 
 // @public
@@ -445,6 +490,17 @@ export function resolveLinkRenderMode(link: {
     component?: string;
     cardinality?: string;
 }, fieldComponent?: string): LinkRenderMode;
+
+// @public
+export function selectChoices(options: FieldOptions | undefined): string[];
+
+// @public
+export interface SelectOptions extends Record<string, unknown> {
+    // (undocumented)
+    badges?: Record<string, BadgeSpec>;
+    // (undocumented)
+    choices: string[];
+}
 
 // @public
 export type SerializedFunction = string;

--- a/docs/adr/0001-badge-component.md
+++ b/docs/adr/0001-badge-component.md
@@ -1,0 +1,38 @@
+# ADR: Badge component authoring and presentation
+
+## Status
+
+Accepted
+
+## Context
+
+List views and forms need to show Select values with semantic color (Task status, Sales Order fulfillment, Issue priority). ERPNext solves this with per-doctype `get_indicator` functions and global status heuristics. Stonecrop already has:
+
+- `FieldOptions` as `string[] | Record<string, unknown>` for Select choices and input config bags
+- `format` serialized functions with row context in ATable
+- No badge component or color map in schema today
+
+We considered three designs:
+
+1. A new `badge` field sibling to `format` with a single `resolveBadge()` function
+2. A BadgeKit cascade with app palettes, doctype-level indicators, and click-to-filter
+3. Extending `options` for simple maps and `format` returning a badge descriptor for complex cases
+
+We also needed different paint in tables vs forms: full cell fill in ATable, left-border accent inside the input in AForm.
+
+## Decision
+
+- **Mapping:** Simple cases use `options` — either a bare `{ value: variant }` map or `{ choices, badges }`. Complex cases use existing `format`, which may return `{ label, variant, color? }`.
+- **Paint:** Theme tokens `--sc-badge-{variant}-bg|text|accent`. Apps may override with `color` on a map entry or descriptor.
+- **Component:** `ABadge` in `@stonecrop/aform` with required `presentation`: `cell-fill` (table) or `input-accent` (form).
+- **Wiring:** `schemaToColumns` auto-attaches `ABadge` for Select fields with badge options. ACell renders format descriptors as `cell-fill`. ADropdown applies `input-accent` in display and edit when a badge resolves.
+
+No new schema property, no doctype-level indicator registry, no click-to-filter in v1.
+
+## Consequences
+
+- Plain `string[]` Selects stay uncolored; badge maps are an explicit opt-in.
+- `isSelectChoiceMap` must distinguish badge maps from quantity/currency config objects.
+- AForm passes `record` to fields so `format` can read sibling columns in display mode.
+- ACell renders `'ABadge'` by global registration to avoid an aform↔atable import cycle.
+- Future work could add doctype-level indicators or filter actions without changing the descriptor shape.

--- a/docs/adr/0001-badge-component.md
+++ b/docs/adr/0001-badge-component.md
@@ -25,7 +25,7 @@ We also needed different paint in tables vs forms: full cell fill in ATable, lef
 - **Mapping:** Simple cases use `options` — either a bare `{ value: variant }` map or `{ choices, badges }`. Complex cases use existing `format`, which may return `{ label, variant, color? }`.
 - **Paint:** Theme tokens `--sc-badge-{variant}-bg|text|accent`. Apps may override with `color` on a map entry or descriptor.
 - **Component:** `ABadge` in `@stonecrop/aform` with required `presentation`: `cell-fill` (table) or `input-accent` (form).
-- **Wiring:** `schemaToColumns` auto-attaches `ABadge` for Select fields with badge options. ACell renders format descriptors as `cell-fill`. ADropdown applies `input-accent` in display and edit when a badge resolves.
+- **Wiring:** `schemaToColumns` passes `options` through to `TableColumn`. ACell renders `ABadge` as `cell-fill` when `format` returns a descriptor, or when the column's `options` carry a badge map. ADropdown applies `input-accent` in display and edit when a badge resolves.
 
 No new schema property, no doctype-level indicator registry, no click-to-filter in v1.
 
@@ -33,6 +33,6 @@ No new schema property, no doctype-level indicator registry, no click-to-filter 
 
 - Plain `string[]` Selects stay uncolored; badge maps are an explicit opt-in.
 - `isSelectChoiceMap` must distinguish badge maps from quantity/currency config objects.
-- AForm passes `record` to fields so `format` can read sibling columns in display mode.
+- Form `format` functions get no row context. ATable supplies `{ table, row, column }` from the store, which owns the data; the AForm equivalent would have to be built the same way, at the call site — not by passing the data model down as a prop to every field.
 - ACell renders `'ABadge'` by global registration to avoid an aform↔atable import cycle.
 - Future work could add doctype-level indicators or filter actions without changing the descriptor shape.

--- a/docs/adr/0001-badge-component.md
+++ b/docs/adr/0001-badge-component.md
@@ -24,7 +24,7 @@ We also needed different paint in tables vs forms: full cell fill in ATable, lef
 
 - **Mapping:** Simple cases use `options` — either a bare `{ value: variant }` map or `{ choices, badges }`. Complex cases use existing `format`, which may return `{ label, variant, color? }`.
 - **Paint:** Theme tokens `--sc-badge-{variant}-bg|text|accent`. Apps may override with `color` on a map entry or descriptor.
-- **Component:** `ABadge` in `@stonecrop/aform` with required `presentation`: `cell-fill` (table) or `input-accent` (form).
+- **Component:** `ABadge` in `@stonecrop/aform`. `presentation` selects `cell-fill` (table) or `input-accent` (form), defaulting to `cell-fill` because every call site fully determines it.
 - **Wiring:** `schemaToColumns` passes `options` through to `TableColumn`. ACell renders `ABadge` as `cell-fill` when `format` returns a descriptor, or when the column's `options` carry a badge map. ADropdown applies `input-accent` in display and edit when a badge resolves.
 
 No new schema property, no doctype-level indicator registry, no click-to-filter in v1.
@@ -34,5 +34,5 @@ No new schema property, no doctype-level indicator registry, no click-to-filter 
 - Plain `string[]` Selects stay uncolored; badge maps are an explicit opt-in.
 - `isSelectChoiceMap` must distinguish badge maps from quantity/currency config objects.
 - Form `format` functions get no row context. ATable supplies `{ table, row, column }` from the store, which owns the data; the AForm equivalent would have to be built the same way, at the call site — not by passing the data model down as a prop to every field.
-- ACell renders `'ABadge'` by global registration to avoid an aform↔atable import cycle.
+- ACell renders `'ABadge'` by global registration to avoid an aform↔atable import cycle. Consumers installing `@stonecrop/atable` on its own therefore get an inert `<abadge>` element in badge cells, and no warning — Vue does not warn for an unresolved string `:is`.
 - Future work could add doctype-level indicators or filter actions without changing the descriptor shape.

--- a/docs/reference/aform.md
+++ b/docs/reference/aform.md
@@ -9,6 +9,14 @@ description: Schema-driven form components
 
 ## Vue Components
 
+### ABadge
+
+Vue component exported from @stonecrop/aform.
+
+```typescript
+import { ABadge } from '@stonecrop/aform'
+```
+
 ### ACheckbox
 
 Vue component exported from @stonecrop/aform.
@@ -179,6 +187,22 @@ import { Login } from '@stonecrop/aform'
 
 ## Functions
 
+### badgeInputAccentStyle
+
+CSS custom properties for input-accent styling on a native input.
+
+**Signature:**
+
+```typescript
+export declare function badgeInputAccentStyle(descriptor: BadgeDescriptor | undefined): Record<string, string> | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| descriptor | `BadgeDescriptor \| undefined` |  |
+
 ### deserializeFunction
 
 Deserializes a stringified function expression into a typed callable.
@@ -212,6 +236,25 @@ declare function install(app: App): void;
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | app | `App` | Vue app instance |
+
+### resolveFieldBadge
+
+Resolve a field value to a badge descriptor using format (if present) then options map.
+
+**Signature:**
+
+```typescript
+export declare function resolveFieldBadge(value: unknown, options: FieldOptions | undefined, format: string | BadgeFormatFn | undefined, context?: BadgeFormatContext): BadgeDescriptor | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | `unknown` |  |
+| options | `FieldOptions \| undefined` |  |
+| format | `string \| BadgeFormatFn \| undefined` |  |
+| context | `BadgeFormatContext` |  |
 
 ## Interfaces
 
@@ -475,6 +518,29 @@ Emitting is narrower — AFormLink always writes back an `AFormLinkValue`.
 
 ```typescript
 export type AFormLinkModelValue = AFormLinkValue | string | number;
+```
+
+### BadgeFormatContext
+
+Row context passed to badge `format` functions in form fields.
+
+**Definition:**
+
+```typescript
+export type BadgeFormatContext = {
+    record?: Record<string, unknown>;
+    row?: Record<string, unknown>;
+};
+```
+
+### BadgeFormatFn
+
+Badge-aware field `format` function signature.
+
+**Definition:**
+
+```typescript
+export type BadgeFormatFn = (value: unknown, context: BadgeFormatContext) => string | BadgeDescriptor;
 ```
 
 ### ComponentProps

--- a/docs/reference/atable.md
+++ b/docs/reference/atable.md
@@ -156,7 +156,7 @@ createTableStore: (initData: {
 }) => import("pinia").Store<`table-${string}`, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -177,12 +177,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -203,6 +204,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -1028,7 +1030,7 @@ createTableStore: (initData: {
 }, "columns" | "config" | "connectionHandles" | "connectionPaths" | "filterState" | "ganttBars" | "modal" | "rows" | "sortState" | "updates" | "linkResolver">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1049,12 +1051,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1075,6 +1078,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -1900,7 +1904,7 @@ createTableStore: (initData: {
 }, "display" | "table" | "filteredRows" | "hasPinnedColumns" | "isGanttView" | "isTreeView" | "isDependencyGraphEnabled" | "numberedRowWidth" | "zeroColumn">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1921,12 +1925,13 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1947,6 +1952,7 @@ createTableStore: (initData: {
         cellComponent?: string | undefined;
         cellComponentProps?: Record<string, any> | undefined;
         modalComponentExtraProps?: Record<string, any> | undefined;
+        options?: import("@stonecrop/schema").FieldOptions | undefined;
         isGantt?: boolean | undefined;
         ganttComponent?: string | undefined;
         colspan?: number | undefined;
@@ -3255,7 +3261,7 @@ Schema-based callers should author columns as `ColumnSchema[]` (using `fieldname
 
 ```typescript
 export interface TableColumn {
-  format?: string | ((value: any, context: CellContext) => string);
+  format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor);
   linkDoctype?: string;
   mask?: (value: any) => any;
   modalComponent?: string | ((context: CellContext) => string);
@@ -3268,7 +3274,7 @@ export interface TableColumn {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| format? | `string \| ((value: any, context: CellContext) => string)` | Widens `ColumnSchema.format` (string-only) to also accept a live function at runtime. Serialized string functions are deserialized by the table store's `getFormattedValue`. |
+| format? | `string \| ((value: any, context: CellContext) => string \| BadgeDescriptor)` | Widens `ColumnSchema.format` (string-only) to also accept a live function at runtime. Serialized string functions are deserialized by the table store's `getFormattedValue`. May return a plain string, HTML, or a `BadgeDescriptor`. |
 | linkDoctype? | `string` | For link columns (those carrying `doctype`): the target doctype slug used by the `linkResolver` to look up display text for bare ID values. Set automatically by `schemaToColumns` from the field's `doctype` property. |
 | mask? | `(value: any) => any` | Input mask applied to the cell value before display. Accepts a live function only — masks cannot be serialized to JSON so they are absent from `ColumnSchema`. |
 | modalComponent? | `string \| ((context: CellContext) => string)` | Widens `ColumnSchema.modalComponent` (string-only) to also accept a factory function. When a function is provided it receives the cell context and returns the component name. The cell context exposes: - `row` — the row object for the current cell - `column` — the column object for the current cell - `table` — the table object |

--- a/docs/reference/atable.md
+++ b/docs/reference/atable.md
@@ -156,7 +156,7 @@ createTableStore: (initData: {
 }) => import("pinia").Store<`table-${string}`, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -183,7 +183,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1030,7 +1030,7 @@ createTableStore: (initData: {
 }, "columns" | "config" | "connectionHandles" | "connectionPaths" | "filterState" | "ganttBars" | "modal" | "rows" | "sortState" | "updates" | "linkResolver">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1057,7 +1057,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1904,7 +1904,7 @@ createTableStore: (initData: {
 }, "display" | "table" | "filteredRows" | "hasPinnedColumns" | "isGanttView" | "isTreeView" | "isDependencyGraphEnabled" | "numberedRowWidth" | "zeroColumn">, Pick<{
     columns: import("vue").Ref<{
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;
@@ -1931,7 +1931,7 @@ createTableStore: (initData: {
         colspan?: number | undefined;
     }[], TableColumn[] | {
         name: string;
-        format?: string | ((value: any, context: CellContext) => string | import("@stonecrop/schema").BadgeDescriptor) | undefined;
+        format?: string | ((value: any, context: CellContext) => string | BadgeDescriptor) | undefined;
         modalComponent?: string | ((context: CellContext) => string) | undefined;
         mask?: ((value: any) => any) | undefined;
         linkDoctype?: string | undefined;

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -284,6 +284,22 @@ export declare function getRecordIdField(fields: readonly DoctypeField[]): strin
 |-----------|------|-------------|
 | fields | `readonly DoctypeField[]` | the doctype's top-level fields |
 
+### hasBadgeOptions
+
+Whether field options carry any badge mapping.
+
+**Signature:**
+
+```typescript
+export declare function hasBadgeOptions(options: FieldOptions | undefined): boolean;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### isActionAllowedInState
 
 Whether a workflow action may run from `currentState`.
@@ -305,6 +321,54 @@ export declare function isActionAllowedInState(action: {
 | action | `{ allowedStates?: string[] \| null; }` |  |
 | currentState | `string` |  |
 
+### isBadgeDescriptor
+
+True when `value` is a resolved badge descriptor for ACell / ADropdown.
+
+**Signature:**
+
+```typescript
+export declare function isBadgeDescriptor(value: unknown): value is BadgeDescriptor;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | `unknown` |  |
+
+### isSelectChoiceMap
+
+True when `options` is a Select choice map (`{ Open: "warning", ... }` or `{ choices: [...], badges: {...} }`), not a quantity/currency/code config bag.
+
+**Signature:**
+
+```typescript
+export declare function isSelectChoiceMap(options: FieldOptions | undefined): options is Record<string, BadgeSpec>;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
+### isSelectOptions
+
+True when `options` uses the structured SelectOptions shape.
+
+**Signature:**
+
+```typescript
+export declare function isSelectOptions(options: FieldOptions | undefined): options is SelectOptions;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### linkDisplayFieldname
 
 Build the payload key for a link field's display text (e.g. `customerId__display`).
@@ -320,6 +384,23 @@ export declare function linkDisplayFieldname(fieldname: string): string;
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | fieldname | `string` |  |
+
+### lookupBadge
+
+Resolve a stored choice value to a badge descriptor using field options.
+
+**Signature:**
+
+```typescript
+export declare function lookupBadge(options: FieldOptions | undefined, key: string | undefined): BadgeDescriptor | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+| key | `string \| undefined` |  |
 
 ### mergeIntrospectedDoctype
 
@@ -430,6 +511,22 @@ export declare function resolveLinkRenderMode(link: {
 | link | `{ component?: string; cardinality?: string; }` | the link declaration (only `component` and `cardinality` are consulted) |
 | fieldComponent | `string` | the linked field's own `component`, used when the declaration names none |
 
+### selectChoices
+
+Dropdown / filter choice strings.
+
+**Signature:**
+
+```typescript
+export declare function selectChoices(options: FieldOptions | undefined): string[];
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### snakeToCamel
 
 Converts snake_case to camelCase
@@ -528,6 +625,50 @@ export declare function validateField(data: unknown): ValidationResult;
 
 ## Interfaces
 
+### BadgeDescriptor
+
+Resolved badge for rendering. Returned by `format` or built from an options map.
+
+**Definition:**
+
+```typescript
+export interface BadgeDescriptor {
+  color?: string;
+  label: string;
+  variant?: BadgeVariant;
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| color? | `string` |  |
+| label | `string` |  |
+| variant? | `BadgeVariant` |  |
+
+### BadgeSpecObject
+
+Per-choice badge configuration in a Select options map.
+
+**Definition:**
+
+```typescript
+export interface BadgeSpecObject {
+  color?: string;
+  label?: string;
+  variant?: BadgeVariant;
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| color? | `string` |  |
+| label? | `string` |  |
+| variant? | `BadgeVariant` |  |
+
 ### ColumnSchema
 
 Authoring contract for doctype field declarations that can be rendered as table columns. Pass a `ColumnSchema[]` array to ATable's `:schema` prop; `schemaToColumns` converts it to `TableColumn[]` internally — callers working from a doctype schema never need to construct `TableColumn` directly.
@@ -557,6 +698,7 @@ export interface ColumnSchema {
   label?: string;
   modalComponent?: string;
   modalComponentExtraProps?: Record<string, any>;
+  options?: FieldOptions;
   pinned?: boolean;
   resizable?: boolean;
   sortable?: boolean;
@@ -580,13 +722,14 @@ export interface ColumnSchema {
 | filterComponent? | `string` | Registered component name used when `filterType` is `'component'`. |
 | filterOptions? | `any[]` | Static option list for `filterType: 'select'`. When absent, options are derived from the unique values present in the column's rows. |
 | filterType? | `'text' \| 'select' \| 'number' \| 'date' \| 'dateRange' \| 'checkbox' \| 'component'` | The type of filter control to render. When absent, a default is derived from the `component`'s `ComponentCategory` (`boolean` → `checkbox`, `date` → `date`, `datetime` → `dateRange`, `select` → `select`, `number` → `number`, everything else — including an unknown component — → `text`). |
-| format? | `string` | Serialized function string used to format the cell value for display. Deserialized at render time by the table store's `getFormattedValue`. `TableColumn.format` widens this to also accept a live function directly. |
+| format? | `string` | Serialized function string used to format the cell value for display. Deserialized at render time by the table store's `getFormattedValue`. May return a plain string, HTML, or a `BadgeDescriptor`. `TableColumn.format` widens this to also accept a live function. |
 | ganttComponent? | `string` | Registered component name used to render Gantt bars in this column. Only applicable for Gantt tables. |
 | hidden? | `boolean` | When `true`, the field is excluded from the derived columns by `schemaToColumns`. |
 | isGantt? | `boolean` | When `true`, this column is treated as a Gantt bar column. Only applicable for Gantt tables. |
 | label? | `string` | Human-readable column header. When absent, ATable assigns labels alphabetically (A, B, C, …). |
 | modalComponent? | `string` | Registered component name rendered in the cell's modal editor. String-only — functions cannot appear in schema JSON. `TableColumn.modalComponent` widens this to also accept a factory function. The following props are automatically passed to the modal component: - `colIndex` — the column index of the current cell - `rowIndex` — the row index of the current cell - `store` — the table data store |
 | modalComponentExtraProps? | `Record<string, any>` | Extra props passed to `modalComponent` in addition to the standard cell props. Only applicable when `modalComponent` is set. |
+| options? | `FieldOptions` | Type-specific field options — Select choices, badge maps, quantity/currency config, etc. Spreads through `schemaToColumns` to `TableColumn`. |
 | pinned? | `boolean` | When `true`, the column is pinned to the left side of the table. |
 | resizable? | `boolean` | When `true`, the column can be resized by dragging the header edge. |
 | sortable? | `boolean` | When `true`, clicking the column header sorts the table by this column. |
@@ -899,6 +1042,26 @@ export interface MergeResult {
 | doctype | `AuthoredDoctype` | The authored doctype with `source` markers added and nothing else changed. |
 | drift | `DoctypeDrift` | Advisory report. Never applied. |
 
+### SelectOptions
+
+Select field options when choices carry badge colors.
+
+**Definition:**
+
+```typescript
+export interface SelectOptions {
+  badges?: Record<string, BadgeSpec>;
+  choices: string[];
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| badges? | `Record<string, BadgeSpec>` |  |
+| choices | `string[]` |  |
+
 ### TableField
 
 An inline table whose columns are defined directly in the schema (no linked doctype). Use when the table data does not warrant a separate doctype.
@@ -1014,7 +1177,7 @@ export interface ValueField {
 | doctype? | `string` | Target doctype slug. Presence is what makes a field a link. How it renders is decided by `component`, not by this: `AFormLink` renders an inline id-picker, while `AForm`/`ATable` expand the target (see `linkRenderMode`). Expansion metadata — backlink, fetch strategy, authoritative cardinality — lives in the doctype's `links` map, which is additive and never required for a plain foreign key. |
 | edit? | `boolean` | Whether the field is editable in table cell context |
 | fieldname | `string` | Unique identifier for this field within its doctype |
-| format? | `string` | Serialized `(value) => string` function for display formatting — distinct from `mask` (input). Spreads through `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by ATable's `getFormattedValue`. |
+| format? | `string` | Serialized display formatter — distinct from `mask` (input). Spreads through `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by ATable's `getFormattedValue`. Returns a plain string, HTML, or a `BadgeDescriptor` for badge cells. When a descriptor is returned it wins over any badge map on `options`. |
 | hidden? | `boolean` | Whether the field is hidden from the UI |
 | kind | `'field'` | Discriminator — identifies this as a value-holding field |
 | label? | `string` | Human-readable label |
@@ -1049,6 +1212,36 @@ A doctype as it exists on disk: a plain object that may carry keys this package 
 
 ```typescript
 export type AuthoredDoctype = Record<string, unknown>;
+```
+
+### BadgePresentation
+
+Where ABadge paints the same descriptor.
+
+**Definition:**
+
+```typescript
+export type BadgePresentation = 'cell-fill' | 'input-accent';
+```
+
+### BadgeSpec
+
+Value in a choice→badge map: shorthand variant or object form.
+
+**Definition:**
+
+```typescript
+export type BadgeSpec = BadgeVariant | BadgeSpecObject;
+```
+
+### BadgeVariant
+
+Semantic badge variant. Maps to theme tokens `--sc-badge-{variant}-*`.
+
+**Definition:**
+
+```typescript
+export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'brand';
 ```
 
 ### Cardinality
@@ -1452,7 +1645,7 @@ export const FetchStrategy: z.ZodDiscriminatedUnion<[z.ZodObject<{
 
 Field options - flexible bag for type-specific configuration.
 
-Usage: - Select: array of choices (["Draft", "Submitted", "Cancelled"]) - Decimal: config object ( precision: 10, scale: 2 ) - Code: config object ( language: "python" )
+Usage: - Select: array of choices (["Draft", "Submitted", "Cancelled"]) - Select with badges:  choices: [...], badges:  Open: "warning", ...   or bare map - Decimal: config object ( precision: 10, scale: 2 ) - Code: config object ( language: "python" )
 
 Deliberately *not* a bare string: a string once meant "link target", which made the value's shape encode its meaning. That job belongs to `ValueField.doctype`, leaving this a plain choices-or-config bag.
 

--- a/examples/aform/assets/basic_form_schema.json
+++ b/examples/aform/assets/basic_form_schema.json
@@ -43,6 +43,20 @@
 		"mask": "(locale) => { if (locale === 'en-US') { return '(###) ###-####' } else if (locale === 'en-IN') { return '####-######'} }"
 	},
 	{
+		"fieldname": "status",
+		"kind": "field",
+		"component": "ADropdown",
+		"label": "Status",
+		"options": {
+			"choices": ["Active", "Suspended", "Pending"],
+			"badges": {
+				"Active": "success",
+				"Suspended": "warning",
+				"Pending": "brand"
+			}
+		}
+	},
+	{
 		"fieldname": "attach_file",
 		"kind": "field",
 		"component": "AFileAttach",

--- a/examples/aform/assets/basic_table_schema.json
+++ b/examples/aform/assets/basic_table_schema.json
@@ -60,10 +60,18 @@
 			{
 				"fieldname": "status",
 				"label": "Status",
-				"component": "ADropdown",
+				"component": "ABadge",
 				"align": "center",
 				"edit": true,
-				"width": "14ch"
+				"width": "14ch",
+				"options": {
+					"choices": ["Confirmed", "Pending", "Backordered"],
+					"badges": {
+						"Confirmed": "success",
+						"Pending": "warning",
+						"Backordered": "danger"
+					}
+				}
 			}
 		],
 		"config": {

--- a/examples/aform/dropdown.story.vue
+++ b/examples/aform/dropdown.story.vue
@@ -78,8 +78,10 @@ function delay(ms: number) {
 	display: flex;
 	flex-direction: row;
 	align-items: top;
+	gap: 1rem;
 	margin: 0px;
-	padding-left: 1ch;
-	padding-right: 1ch;
+	/* .aform_field-label is absolutely positioned at top:0 with translateY(-50%), so a bare
+	   field component needs vertical room from its container the way AForm's padding gives it. */
+	padding: 1rem 1ch 0;
 }
 </style>

--- a/examples/aform/form.story.vue
+++ b/examples/aform/form.story.vue
@@ -143,6 +143,7 @@ const data = ref({
 	date: '1990-04-15',
 	card: '4111111111111111',
 	phone: '',
+	status: 'Active',
 })
 
 // Table variants: rows keyed by fieldname at each nesting level.

--- a/schema/api.md
+++ b/schema/api.md
@@ -279,6 +279,22 @@ export declare function getRecordIdField(fields: readonly DoctypeField[]): strin
 |-----------|------|-------------|
 | fields | `readonly DoctypeField[]` | the doctype's top-level fields |
 
+### hasBadgeOptions
+
+Whether field options carry any badge mapping.
+
+**Signature:**
+
+```typescript
+export declare function hasBadgeOptions(options: FieldOptions | undefined): boolean;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### isActionAllowedInState
 
 Whether a workflow action may run from `currentState`.
@@ -300,6 +316,54 @@ export declare function isActionAllowedInState(action: {
 | action | `{ allowedStates?: string[] \| null; }` |  |
 | currentState | `string` |  |
 
+### isBadgeDescriptor
+
+True when `value` is a resolved badge descriptor for ACell / ADropdown.
+
+**Signature:**
+
+```typescript
+export declare function isBadgeDescriptor(value: unknown): value is BadgeDescriptor;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | `unknown` |  |
+
+### isSelectChoiceMap
+
+True when `options` is a Select choice map (`{ Open: "warning", ... }` or `{ choices: [...], badges: {...} }`), not a quantity/currency/code config bag.
+
+**Signature:**
+
+```typescript
+export declare function isSelectChoiceMap(options: FieldOptions | undefined): options is Record<string, BadgeSpec>;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
+### isSelectOptions
+
+True when `options` uses the structured SelectOptions shape.
+
+**Signature:**
+
+```typescript
+export declare function isSelectOptions(options: FieldOptions | undefined): options is SelectOptions;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### linkDisplayFieldname
 
 Build the payload key for a link field's display text (e.g. `customerId__display`).
@@ -315,6 +379,23 @@ export declare function linkDisplayFieldname(fieldname: string): string;
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | fieldname | `string` |  |
+
+### lookupBadge
+
+Resolve a stored choice value to a badge descriptor using field options.
+
+**Signature:**
+
+```typescript
+export declare function lookupBadge(options: FieldOptions | undefined, key: string | undefined): BadgeDescriptor | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+| key | `string \| undefined` |  |
 
 ### mergeIntrospectedDoctype
 
@@ -425,6 +506,22 @@ export declare function resolveLinkRenderMode(link: {
 | link | `{ component?: string; cardinality?: string; }` | the link declaration (only `component` and `cardinality` are consulted) |
 | fieldComponent | `string` | the linked field's own `component`, used when the declaration names none |
 
+### selectChoices
+
+Dropdown / filter choice strings.
+
+**Signature:**
+
+```typescript
+export declare function selectChoices(options: FieldOptions | undefined): string[];
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| options | `FieldOptions \| undefined` |  |
+
 ### snakeToCamel
 
 Converts snake_case to camelCase
@@ -523,6 +620,50 @@ export declare function validateField(data: unknown): ValidationResult;
 
 ## Interfaces
 
+### BadgeDescriptor
+
+Resolved badge for rendering. Returned by `format` or built from an options map.
+
+**Definition:**
+
+```typescript
+export interface BadgeDescriptor {
+  color?: string;
+  label: string;
+  variant?: BadgeVariant;
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| color? | `string` |  |
+| label | `string` |  |
+| variant? | `BadgeVariant` |  |
+
+### BadgeSpecObject
+
+Per-choice badge configuration in a Select options map.
+
+**Definition:**
+
+```typescript
+export interface BadgeSpecObject {
+  color?: string;
+  label?: string;
+  variant?: BadgeVariant;
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| color? | `string` |  |
+| label? | `string` |  |
+| variant? | `BadgeVariant` |  |
+
 ### ColumnSchema
 
 Authoring contract for doctype field declarations that can be rendered as table columns. Pass a `ColumnSchema[]` array to ATable's `:schema` prop; `schemaToColumns` converts it to `TableColumn[]` internally — callers working from a doctype schema never need to construct `TableColumn` directly.
@@ -552,6 +693,7 @@ export interface ColumnSchema {
   label?: string;
   modalComponent?: string;
   modalComponentExtraProps?: Record<string, any>;
+  options?: FieldOptions;
   pinned?: boolean;
   resizable?: boolean;
   sortable?: boolean;
@@ -575,13 +717,14 @@ export interface ColumnSchema {
 | filterComponent? | `string` | Registered component name used when `filterType` is `'component'`. |
 | filterOptions? | `any[]` | Static option list for `filterType: 'select'`. When absent, options are derived from the unique values present in the column's rows. |
 | filterType? | `'text' \| 'select' \| 'number' \| 'date' \| 'dateRange' \| 'checkbox' \| 'component'` | The type of filter control to render. When absent, a default is derived from the `component`'s `ComponentCategory` (`boolean` → `checkbox`, `date` → `date`, `datetime` → `dateRange`, `select` → `select`, `number` → `number`, everything else — including an unknown component — → `text`). |
-| format? | `string` | Serialized function string used to format the cell value for display. Deserialized at render time by the table store's `getFormattedValue`. `TableColumn.format` widens this to also accept a live function directly. |
+| format? | `string` | Serialized function string used to format the cell value for display. Deserialized at render time by the table store's `getFormattedValue`. May return a plain string, HTML, or a `BadgeDescriptor`. `TableColumn.format` widens this to also accept a live function. |
 | ganttComponent? | `string` | Registered component name used to render Gantt bars in this column. Only applicable for Gantt tables. |
 | hidden? | `boolean` | When `true`, the field is excluded from the derived columns by `schemaToColumns`. |
 | isGantt? | `boolean` | When `true`, this column is treated as a Gantt bar column. Only applicable for Gantt tables. |
 | label? | `string` | Human-readable column header. When absent, ATable assigns labels alphabetically (A, B, C, …). |
 | modalComponent? | `string` | Registered component name rendered in the cell's modal editor. String-only — functions cannot appear in schema JSON. `TableColumn.modalComponent` widens this to also accept a factory function. The following props are automatically passed to the modal component: - `colIndex` — the column index of the current cell - `rowIndex` — the row index of the current cell - `store` — the table data store |
 | modalComponentExtraProps? | `Record<string, any>` | Extra props passed to `modalComponent` in addition to the standard cell props. Only applicable when `modalComponent` is set. |
+| options? | `FieldOptions` | Type-specific field options — Select choices, badge maps, quantity/currency config, etc. Spreads through `schemaToColumns` to `TableColumn`. |
 | pinned? | `boolean` | When `true`, the column is pinned to the left side of the table. |
 | resizable? | `boolean` | When `true`, the column can be resized by dragging the header edge. |
 | sortable? | `boolean` | When `true`, clicking the column header sorts the table by this column. |
@@ -894,6 +1037,26 @@ export interface MergeResult {
 | doctype | `AuthoredDoctype` | The authored doctype with `source` markers added and nothing else changed. |
 | drift | `DoctypeDrift` | Advisory report. Never applied. |
 
+### SelectOptions
+
+Select field options when choices carry badge colors.
+
+**Definition:**
+
+```typescript
+export interface SelectOptions {
+  badges?: Record<string, BadgeSpec>;
+  choices: string[];
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| badges? | `Record<string, BadgeSpec>` |  |
+| choices | `string[]` |  |
+
 ### TableField
 
 An inline table whose columns are defined directly in the schema (no linked doctype). Use when the table data does not warrant a separate doctype.
@@ -1009,7 +1172,7 @@ export interface ValueField {
 | doctype? | `string` | Target doctype slug. Presence is what makes a field a link. How it renders is decided by `component`, not by this: `AFormLink` renders an inline id-picker, while `AForm`/`ATable` expand the target (see `linkRenderMode`). Expansion metadata — backlink, fetch strategy, authoritative cardinality — lives in the doctype's `links` map, which is additive and never required for a plain foreign key. |
 | edit? | `boolean` | Whether the field is editable in table cell context |
 | fieldname | `string` | Unique identifier for this field within its doctype |
-| format? | `string` | Serialized `(value) => string` function for display formatting — distinct from `mask` (input). Spreads through `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by ATable's `getFormattedValue`. |
+| format? | `string` | Serialized display formatter — distinct from `mask` (input). Spreads through `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by ATable's `getFormattedValue`. Returns a plain string, HTML, or a `BadgeDescriptor` for badge cells. When a descriptor is returned it wins over any badge map on `options`. |
 | hidden? | `boolean` | Whether the field is hidden from the UI |
 | kind | `'field'` | Discriminator — identifies this as a value-holding field |
 | label? | `string` | Human-readable label |
@@ -1044,6 +1207,36 @@ A doctype as it exists on disk: a plain object that may carry keys this package 
 
 ```typescript
 export type AuthoredDoctype = Record<string, unknown>;
+```
+
+### BadgePresentation
+
+Where ABadge paints the same descriptor.
+
+**Definition:**
+
+```typescript
+export type BadgePresentation = 'cell-fill' | 'input-accent';
+```
+
+### BadgeSpec
+
+Value in a choice→badge map: shorthand variant or object form.
+
+**Definition:**
+
+```typescript
+export type BadgeSpec = BadgeVariant | BadgeSpecObject;
+```
+
+### BadgeVariant
+
+Semantic badge variant. Maps to theme tokens `--sc-badge-{variant}-*`.
+
+**Definition:**
+
+```typescript
+export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'brand';
 ```
 
 ### Cardinality
@@ -1447,7 +1640,7 @@ export const FetchStrategy: z.ZodDiscriminatedUnion<[z.ZodObject<{
 
 Field options - flexible bag for type-specific configuration.
 
-Usage: - Select: array of choices (["Draft", "Submitted", "Cancelled"]) - Decimal: config object ( precision: 10, scale: 2 ) - Code: config object ( language: "python" )
+Usage: - Select: array of choices (["Draft", "Submitted", "Cancelled"]) - Select with badges:  choices: [...], badges:  Open: "warning", ...   or bare map - Decimal: config object ( precision: 10, scale: 2 ) - Code: config object ( language: "python" )
 
 Deliberately *not* a bare string: a string once meant "link target", which made the value's shape encode its meaning. That job belongs to `ValueField.doctype`, leaving this a plain choices-or-config bag.
 

--- a/schema/src/badge.ts
+++ b/schema/src/badge.ts
@@ -137,9 +137,15 @@ export function selectChoices(options: FieldOptions | undefined): string[] {
 	return []
 }
 
-function normalizeBadgeSpec(spec: BadgeSpec, key: string): BadgeDescriptor {
+function normalizeBadgeSpec(spec: unknown, key: string): BadgeDescriptor {
 	if (isBadgeVariant(spec)) {
 		return { label: key, variant: spec }
+	}
+	// A malformed spec still names a real choice, so keep the label and drop only the styling.
+	// Reading `.variant`/`.color` off an unvalidated value is what let a misspelt variant reach the
+	// DOM as an unmatched class, and threw outright on null.
+	if (!isBadgeSpecObject(spec)) {
+		return { label: key }
 	}
 	return {
 		label: spec.label ?? key,

--- a/schema/src/badge.ts
+++ b/schema/src/badge.ts
@@ -1,0 +1,185 @@
+import type { FieldOptions } from './field'
+
+/**
+ * Semantic badge variant. Maps to theme tokens `--sc-badge-{variant}-*`.
+ * @public
+ */
+export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'brand'
+
+/**
+ * Where ABadge paints the same descriptor.
+ * @public
+ */
+export type BadgePresentation = 'cell-fill' | 'input-accent'
+
+/**
+ * Per-choice badge configuration in a Select options map.
+ * @public
+ */
+export interface BadgeSpecObject {
+	variant?: BadgeVariant
+	color?: string
+	label?: string
+}
+
+/**
+ * Value in a choice→badge map: shorthand variant or object form.
+ * @public
+ */
+export type BadgeSpec = BadgeVariant | BadgeSpecObject
+
+/**
+ * Select field options when choices carry badge colors.
+ * @public
+ */
+export interface SelectOptions extends Record<string, unknown> {
+	choices: string[]
+	badges?: Record<string, BadgeSpec>
+}
+
+/**
+ * Resolved badge for rendering. Returned by `format` or built from an options map.
+ * @public
+ */
+export interface BadgeDescriptor {
+	label: string
+	variant?: BadgeVariant
+	color?: string
+}
+
+const BADGE_VARIANTS = new Set<string>(['neutral', 'success', 'warning', 'danger', 'brand'])
+
+const BADGE_SPEC_OBJECT_KEYS = new Set(['variant', 'color', 'label'])
+
+function isOptionsRecord(options: FieldOptions): options is Record<string, unknown> {
+	return !Array.isArray(options)
+}
+
+function isBadgeVariant(value: unknown): value is BadgeVariant {
+	return typeof value === 'string' && BADGE_VARIANTS.has(value)
+}
+
+function isBadgeSpecObject(value: unknown): value is BadgeSpecObject {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+	for (const key of Object.keys(value)) {
+		if (!BADGE_SPEC_OBJECT_KEYS.has(key)) return false
+	}
+	const obj = value as BadgeSpecObject
+	if (obj.variant !== undefined && !isBadgeVariant(obj.variant)) return false
+	if (obj.color !== undefined && typeof obj.color !== 'string') return false
+	if (obj.label !== undefined && typeof obj.label !== 'string') return false
+	return true
+}
+
+function isBadgeSpec(value: unknown): value is BadgeSpec {
+	return isBadgeVariant(value) || isBadgeSpecObject(value)
+}
+
+function asSelectOptions(options: Record<string, unknown>): SelectOptions | undefined {
+	if (!('choices' in options) || !Array.isArray(options.choices)) return undefined
+	return options as unknown as SelectOptions
+}
+
+/**
+ * True when `value` is a resolved badge descriptor for ACell / ADropdown.
+ * @public
+ */
+export function isBadgeDescriptor(value: unknown): value is BadgeDescriptor {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+	const obj = value as BadgeDescriptor
+	if (typeof obj.label !== 'string') return false
+	if (obj.variant !== undefined && !isBadgeVariant(obj.variant)) return false
+	if (obj.color !== undefined && typeof obj.color !== 'string') return false
+	return true
+}
+
+/**
+ * True when `options` is a Select choice map (`{ Open: "warning", ... }` or
+ * `{ choices: [...], badges: {...} }`), not a quantity/currency/code config bag.
+ * @public
+ */
+export function isSelectChoiceMap(options: FieldOptions | undefined): options is Record<string, BadgeSpec> {
+	if (options === undefined || Array.isArray(options) || !isOptionsRecord(options)) return false
+	const structured = asSelectOptions(options)
+	if (structured) {
+		const badges = structured.badges
+		if (badges === undefined) return false
+		return Object.values(badges).every(isBadgeSpec)
+	}
+	const entries = Object.entries(options)
+	if (entries.length === 0) return false
+	return entries.every(([, value]) => isBadgeSpec(value))
+}
+
+/**
+ * True when `options` uses the structured SelectOptions shape.
+ * @public
+ */
+export function isSelectOptions(options: FieldOptions | undefined): options is SelectOptions {
+	if (options === undefined || Array.isArray(options) || !isOptionsRecord(options)) return false
+	return asSelectOptions(options) !== undefined
+}
+
+/**
+ * Dropdown / filter choice strings.
+ * @public
+ */
+export function selectChoices(options: FieldOptions | undefined): string[] {
+	if (options === undefined) return []
+	if (Array.isArray(options)) return options
+	if (!isOptionsRecord(options)) return []
+	const structured = asSelectOptions(options)
+	if (structured) return structured.choices
+	if (isSelectChoiceMap(options)) return Object.keys(options)
+	return []
+}
+
+function normalizeBadgeSpec(spec: BadgeSpec, key: string): BadgeDescriptor {
+	if (isBadgeVariant(spec)) {
+		return { label: key, variant: spec }
+	}
+	return {
+		label: spec.label ?? key,
+		variant: spec.variant,
+		color: spec.color,
+	}
+}
+
+function lookupFromBareMap(map: Record<string, BadgeSpec>, key: string | undefined): BadgeDescriptor | undefined {
+	if (key === undefined || key === '') return undefined
+	if (!(key in map)) return undefined
+	return normalizeBadgeSpec(map[key], key)
+}
+
+function lookupFromStructured(options: SelectOptions, key: string | undefined): BadgeDescriptor | undefined {
+	if (key === undefined || key === '') return undefined
+	const badges = options.badges
+	if (!badges || !(key in badges)) return undefined
+	return normalizeBadgeSpec(badges[key], key)
+}
+
+/**
+ * Resolve a stored choice value to a badge descriptor using field options.
+ * @public
+ */
+export function lookupBadge(options: FieldOptions | undefined, key: string | undefined): BadgeDescriptor | undefined {
+	if (options === undefined || key === undefined || key === '') return undefined
+	if (Array.isArray(options)) return undefined
+	if (!isOptionsRecord(options)) return undefined
+	const structured = asSelectOptions(options)
+	if (structured) return lookupFromStructured(structured, key)
+	if (isSelectChoiceMap(options)) return lookupFromBareMap(options, key)
+	return undefined
+}
+
+/**
+ * Whether field options carry any badge mapping.
+ * @public
+ */
+export function hasBadgeOptions(options: FieldOptions | undefined): boolean {
+	if (options === undefined || Array.isArray(options)) return false
+	if (!isOptionsRecord(options)) return false
+	const structured = asSelectOptions(options)
+	if (structured) return structured.badges !== undefined && Object.keys(structured.badges).length > 0
+	return isSelectChoiceMap(options)
+}

--- a/schema/src/badge.ts
+++ b/schema/src/badge.ts
@@ -75,9 +75,12 @@ function isBadgeSpec(value: unknown): value is BadgeSpec {
 	return isBadgeVariant(value) || isBadgeSpecObject(value)
 }
 
-function asSelectOptions(options: Record<string, unknown>): SelectOptions | undefined {
-	if (!('choices' in options) || !Array.isArray(options.choices)) return undefined
-	return options as unknown as SelectOptions
+/**
+ * Narrows an options record to the structured `{ choices, badges }` form. A type predicate rather
+ * than a cast: `SelectOptions` requires `choices`, so asserting into it trips `no-unsafe-type-assertion`.
+ */
+function isStructuredSelectOptions(options: Record<string, unknown>): options is SelectOptions {
+	return Array.isArray(options.choices)
 }
 
 /**
@@ -86,7 +89,9 @@ function asSelectOptions(options: Record<string, unknown>): SelectOptions | unde
  */
 export function isBadgeDescriptor(value: unknown): value is BadgeDescriptor {
 	if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
-	const obj = value as BadgeDescriptor
+	// Partial<> keeps this a widening assertion; asserting into BadgeDescriptor itself (required
+	// `label`) narrows, which `no-unsafe-type-assertion` rejects.
+	const obj = value as Partial<BadgeDescriptor>
 	if (typeof obj.label !== 'string') return false
 	if (obj.variant !== undefined && !isBadgeVariant(obj.variant)) return false
 	if (obj.color !== undefined && typeof obj.color !== 'string') return false
@@ -100,9 +105,8 @@ export function isBadgeDescriptor(value: unknown): value is BadgeDescriptor {
  */
 export function isSelectChoiceMap(options: FieldOptions | undefined): options is Record<string, BadgeSpec> {
 	if (options === undefined || Array.isArray(options) || !isOptionsRecord(options)) return false
-	const structured = asSelectOptions(options)
-	if (structured) {
-		const badges = structured.badges
+	if (isStructuredSelectOptions(options)) {
+		const badges = options.badges
 		if (badges === undefined) return false
 		return Object.values(badges).every(isBadgeSpec)
 	}
@@ -117,7 +121,7 @@ export function isSelectChoiceMap(options: FieldOptions | undefined): options is
  */
 export function isSelectOptions(options: FieldOptions | undefined): options is SelectOptions {
 	if (options === undefined || Array.isArray(options) || !isOptionsRecord(options)) return false
-	return asSelectOptions(options) !== undefined
+	return isStructuredSelectOptions(options)
 }
 
 /**
@@ -128,8 +132,7 @@ export function selectChoices(options: FieldOptions | undefined): string[] {
 	if (options === undefined) return []
 	if (Array.isArray(options)) return options
 	if (!isOptionsRecord(options)) return []
-	const structured = asSelectOptions(options)
-	if (structured) return structured.choices
+	if (isStructuredSelectOptions(options)) return options.choices
 	if (isSelectChoiceMap(options)) return Object.keys(options)
 	return []
 }
@@ -166,8 +169,7 @@ export function lookupBadge(options: FieldOptions | undefined, key: string | und
 	if (options === undefined || key === undefined || key === '') return undefined
 	if (Array.isArray(options)) return undefined
 	if (!isOptionsRecord(options)) return undefined
-	const structured = asSelectOptions(options)
-	if (structured) return lookupFromStructured(structured, key)
+	if (isStructuredSelectOptions(options)) return lookupFromStructured(options, key)
 	if (isSelectChoiceMap(options)) return lookupFromBareMap(options, key)
 	return undefined
 }
@@ -179,7 +181,6 @@ export function lookupBadge(options: FieldOptions | undefined, key: string | und
 export function hasBadgeOptions(options: FieldOptions | undefined): boolean {
 	if (options === undefined || Array.isArray(options)) return false
 	if (!isOptionsRecord(options)) return false
-	const structured = asSelectOptions(options)
-	if (structured) return structured.badges !== undefined && Object.keys(structured.badges).length > 0
+	if (isStructuredSelectOptions(options)) return options.badges !== undefined && Object.keys(options.badges).length > 0
 	return isSelectChoiceMap(options)
 }

--- a/schema/src/column-schema.ts
+++ b/schema/src/column-schema.ts
@@ -1,3 +1,5 @@
+import type { FieldOptions } from './field'
+
 /**
  * Authoring contract for doctype field declarations that can be rendered as table columns.
  * Pass a `ColumnSchema[]` array to ATable's `:schema` prop; `schemaToColumns` converts it
@@ -144,9 +146,15 @@ export interface ColumnSchema {
 	modalComponentExtraProps?: Record<string, any>
 
 	/**
+	 * Type-specific field options — Select choices, badge maps, quantity/currency config, etc.
+	 * Spreads through `schemaToColumns` to `TableColumn`.
+	 */
+	options?: FieldOptions
+
+	/**
 	 * Serialized function string used to format the cell value for display. Deserialized at
-	 * render time by the table store's `getFormattedValue`. `TableColumn.format` widens this
-	 * to also accept a live function directly.
+	 * render time by the table store's `getFormattedValue`. May return a plain string, HTML, or a
+	 * {@link BadgeDescriptor}. `TableColumn.format` widens this to also accept a live function.
 	 */
 	format?: string
 

--- a/schema/src/field.ts
+++ b/schema/src/field.ts
@@ -9,6 +9,7 @@ import { TableViewConfig } from './table'
  *
  * Usage:
  * - Select: array of choices (["Draft", "Submitted", "Cancelled"])
+ * - Select with badges: \{ choices: [...], badges: \{ Open: "warning", ... \} \} or bare map
  * - Decimal: config object (\{ precision: 10, scale: 2 \})
  * - Code: config object (\{ language: "python" \})
  *
@@ -102,9 +103,10 @@ export interface ValueField {
 	edit?: boolean
 	/** Input mask pattern or serialized function */
 	mask?: string
-	/** Serialized `(value) => string` function for display formatting — distinct from `mask` (input).
-	 *  Spreads through `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by
-	 *  ATable's `getFormattedValue`. */
+	/** Serialized display formatter — distinct from `mask` (input). Spreads through
+	 *  `schemaToColumns` to `ColumnSchema.format`; deserialized at render time by ATable's
+	 *  `getFormattedValue`. Returns a plain string, HTML, or a {@link BadgeDescriptor} for badge
+	 *  cells. When a descriptor is returned it wins over any badge map on `options`. */
 	format?: string
 	/** Per-field interaction mode override */
 	mode?: InteractionMode

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -99,3 +99,21 @@ export { toSlug, toPascalCase, pascalToSnake, snakeToCamel, camelToSnake, snakeT
 
 // Schema-to-column field shape
 export type { ColumnSchema } from './column-schema'
+
+// Badge types and helpers
+export type {
+	BadgeDescriptor,
+	BadgePresentation,
+	BadgeSpec,
+	BadgeSpecObject,
+	BadgeVariant,
+	SelectOptions,
+} from './badge'
+export {
+	hasBadgeOptions,
+	isBadgeDescriptor,
+	isSelectChoiceMap,
+	isSelectOptions,
+	lookupBadge,
+	selectChoices,
+} from './badge'

--- a/schema/tests/badge-malformed-options.spec.ts
+++ b/schema/tests/badge-malformed-options.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { lookupBadge } from '../src/badge'
+
+const TYPO = 'warnin' // one character short of 'warning'
+
+const structured = (spec: unknown) => ({ choices: ['Active'], badges: { Active: spec } }) as never
+
+describe('malformed badge specs', { tags: ['unit'] }, () => {
+	it('CONTROL — a well-formed spec still resolves', () => {
+		expect(lookupBadge(structured('success'), 'Active')).toEqual({
+			label: 'Active',
+			variant: 'success',
+			color: undefined,
+		})
+	})
+
+	it('keeps the label and drops the styling when the variant is misspelt', () => {
+		expect(lookupBadge(structured(TYPO), 'Active')).toEqual({ label: 'Active' })
+	})
+
+	it('does not let an invalid variant reach the caller', () => {
+		expect(lookupBadge(structured({ variant: 'nope' }), 'Active')).toEqual({ label: 'Active' })
+	})
+
+	it('does not throw on a null spec', () => {
+		expect(() => lookupBadge(structured(null), 'Active')).not.toThrow()
+		expect(lookupBadge(structured(null), 'Active')).toEqual({ label: 'Active' })
+	})
+
+	it.each([123, true, ['success'], { variant: 'success', shade: 'dark' }])(
+		'degrades rather than misrenders for %j',
+		spec => {
+			expect(lookupBadge(structured(spec), 'Active')).toEqual({ label: 'Active' })
+		}
+	)
+})

--- a/schema/tests/badge.spec.ts
+++ b/schema/tests/badge.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	hasBadgeOptions,
+	isBadgeDescriptor,
+	isSelectChoiceMap,
+	isSelectOptions,
+	lookupBadge,
+	selectChoices,
+} from '../src/badge'
+
+describe('badge helpers', { tags: ['component'] }, () => {
+	it('isBadgeDescriptor accepts valid descriptors', () => {
+		expect(isBadgeDescriptor({ label: 'Open', variant: 'warning' })).toBe(true)
+		expect(isBadgeDescriptor({ label: 'Custom', color: '#336699' })).toBe(true)
+		expect(isBadgeDescriptor({ label: 'Custom', color: '#336699', variant: 'brand' })).toBe(true)
+		expect(isBadgeDescriptor({ variant: 'success' })).toBe(false)
+		expect(isBadgeDescriptor('Open')).toBe(false)
+	})
+
+	it('isSelectChoiceMap rejects quantity-style config bags', () => {
+		expect(isSelectChoiceMap({ precision: 10, scale: 2 })).toBe(false)
+		expect(isSelectChoiceMap({ language: 'python' })).toBe(false)
+	})
+
+	it('isSelectChoiceMap accepts bare value→variant maps', () => {
+		expect(
+			isSelectChoiceMap({
+				Open: 'warning',
+				Closed: 'success',
+			})
+		).toBe(true)
+	})
+
+	it('isSelectOptions recognizes structured select options', () => {
+		expect(
+			isSelectOptions({
+				choices: ['A', 'B'],
+				badges: { A: 'success' },
+			})
+		).toBe(true)
+	})
+
+	it('selectChoices returns string[] unchanged', () => {
+		expect(selectChoices(['Draft', 'Submitted'])).toEqual(['Draft', 'Submitted'])
+	})
+
+	it('selectChoices returns choices from structured options', () => {
+		expect(
+			selectChoices({
+				choices: ['Open', 'Closed'],
+				badges: { Open: 'warning' },
+			})
+		).toEqual(['Open', 'Closed'])
+	})
+
+	it('selectChoices returns keys from bare badge maps', () => {
+		expect(
+			selectChoices({
+				Open: 'warning',
+				Closed: 'neutral',
+			})
+		).toEqual(['Open', 'Closed'])
+	})
+
+	it('lookupBadge resolves shorthand and object specs', () => {
+		expect(lookupBadge({ Open: 'warning', Closed: { variant: 'success', label: 'Done' } }, 'Open')).toEqual({
+			label: 'Open',
+			variant: 'warning',
+		})
+		expect(lookupBadge({ Closed: { variant: 'success', label: 'Done' } }, 'Closed')).toEqual({
+			label: 'Done',
+			variant: 'success',
+		})
+	})
+
+	it('lookupBadge reads structured badges', () => {
+		expect(
+			lookupBadge(
+				{
+					choices: ['Open', 'Closed'],
+					badges: { Open: 'danger' },
+				},
+				'Open'
+			)
+		).toEqual({ label: 'Open', variant: 'danger' })
+	})
+
+	it('hasBadgeOptions is false for plain string[] selects', () => {
+		expect(hasBadgeOptions(['A', 'B'])).toBe(false)
+	})
+
+	it('hasBadgeOptions is true for bare maps and structured badges', () => {
+		expect(hasBadgeOptions({ Open: 'warning' })).toBe(true)
+		expect(
+			hasBadgeOptions({
+				choices: ['Open'],
+				badges: { Open: 'warning' },
+			})
+		).toBe(true)
+	})
+})

--- a/themes/default/_variables.css
+++ b/themes/default/_variables.css
@@ -19,6 +19,27 @@
 	--sc-brand-success: #155724;
 	--sc-brand-warning: #b99d3e;
 
+	/* Badge variants — table cell fill (bg/text) and form input accent (left border) */
+	--sc-badge-neutral-bg: var(--sc-gray-10);
+	--sc-badge-neutral-text: var(--sc-gray-80);
+	--sc-badge-neutral-accent: var(--sc-gray-50);
+
+	--sc-badge-success-bg: color-mix(in srgb, var(--sc-brand-success) 14%, white);
+	--sc-badge-success-text: var(--sc-brand-success);
+	--sc-badge-success-accent: var(--sc-brand-success);
+
+	--sc-badge-warning-bg: color-mix(in srgb, var(--sc-brand-warning) 18%, white);
+	--sc-badge-warning-text: color-mix(in srgb, var(--sc-brand-warning) 70%, black);
+	--sc-badge-warning-accent: var(--sc-brand-warning);
+
+	--sc-badge-danger-bg: color-mix(in srgb, var(--sc-brand-danger) 12%, white);
+	--sc-badge-danger-text: var(--sc-brand-danger);
+	--sc-badge-danger-accent: var(--sc-brand-danger);
+
+	--sc-badge-brand-bg: color-mix(in srgb, var(--sc-primary-color) 14%, white);
+	--sc-badge-brand-text: var(--sc-brand-color);
+	--sc-badge-brand-accent: var(--sc-primary-color);
+
 	/* Table Colors */
 	--sc-active-cell-background: #ffffff;
 	--sc-active-cell-outline: #e6a92d;


### PR DESCRIPTION
Adds semantic badge coloring for Select/`ADropdown` fields — a “status indicator” pattern — without a new schema property.

- Simple cases: badge maps on `options` — either `{ choices, badges }` or a bare `{ value: variant }` map
- Complex cases: existing `format` may return `{ label, variant, color? }` (`BadgeDescriptor`)
- Plain `string[]` selects stay uncolored; badges are opt-in

**Presentation (two modes, same data)**
- **Form (`ADropdown`):** `input-accent` — white field surface with a 4px left border in the semantic color
- **Table (`ACell`):** `cell-fill` — full cell background using theme tokens

**Packages touched**
- **`@stonecrop/schema`** — `BadgeVariant`, `BadgeDescriptor`, `SelectOptions`, guards/helpers (`lookupBadge`, `hasBadgeOptions`, etc.); `ColumnSchema.options` and widened `format` JSDoc
- **`@stonecrop/themes`** — `--sc-badge-{variant}-bg|text|accent` tokens
- **`@stonecrop/aform`** — `ABadge`, `resolveFieldBadge` / `badgeInputAccentStyle`; `ADropdown` refactored to standard form field layout; `AForm` passes `record` to scalar fields for format context
- **`@stonecrop/atable`** — `ACell` renders `ABadge` from badge options or format descriptors; badge cells use zero padding so cell-fill reaches edges; `format` return type widened to include `BadgeDescriptor`

**Docs & specimens**
- ADR: `docs/adr/0001-badge-component.md`
- `form.story.vue` variants updated with a `status` field (form input-accent + table cell-fill)

<img width="959" height="286" alt="image" src="https://github.com/user-attachments/assets/8027a04d-fc09-4fa7-89ad-cc7faf49a696" />

<img width="967" height="293" alt="image" src="https://github.com/user-attachments/assets/716dce3c-10ff-441f-bd41-192f178c1b7a" />
